### PR TITLE
AGE Official Bugfix: Update Fantasy AGE and Modern AGE spell labels

### DIFF
--- a/ageofficial/package-lock.json
+++ b/ageofficial/package-lock.json
@@ -8912,21 +8912,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/postcss-loader/node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",

--- a/ageofficial/src/components/attack/AttackModal.vue
+++ b/ageofficial/src/components/attack/AttackModal.vue
@@ -93,31 +93,30 @@
                             <option value="Major">Major Action</option>
                         </select>
                 </div>
-				<div class="row">
-  <div class="mb-3 col">
-    <span class="age-input-label" id="basic-addon1">Damage Qualities</span>
-    <input
-      type="text"
-      class="form-control"
-      aria-label="Damage Qualities"
-      placeholder="Qualities eg: Damage [[1d6]]"
-      v-model="attack.damageQualities"
-      aria-describedby="basic-addon1"
-    >
-  </div>
-
-  <div class="mb-3 col">
-    <span class="age-input-label" id="basic-addon1">Damage Flaws</span>
-    <input
-      type="text"
-      class="form-control"
-      aria-label="Damage Flaws"
-      placeholder="Flaws eg: Damage [[1d6]]"
-      v-model="attack.damageFlaws"
-      aria-describedby="basic-addon1"
-    >
-  </div>
-</div>
+                </div>
+                <div class="row">
+                  <div class="mb-3 col">
+                    <span class="age-input-label" id="basic-addon1">Damage Qualities</span>
+                    <input
+                      type="text"
+                      class="form-control"
+                      aria-label="Damage Qualities"
+                      placeholder="Qualities eg: Damage [[1d6]]"
+                      v-model="attack.damageQualities"
+                      aria-describedby="basic-addon1"
+                    >
+                  </div>
+                  <div class="mb-3 col">
+                    <span class="age-input-label" id="basic-addon1">Damage Flaws</span>
+                    <input
+                      type="text"
+                      class="form-control"
+                      aria-label="Damage Flaws"
+                      placeholder="Flaws eg: Damage [[1d6]]"
+                      v-model="attack.damageFlaws"
+                      aria-describedby="basic-addon1"
+                    >
+                  </div>
                 </div>
                 <div class="row" v-if="attack.weaponType === 'Spell Ranged'">
                     <div class="mb-3 col">

--- a/ageofficial/src/components/attack/AttackModal.vue
+++ b/ageofficial/src/components/attack/AttackModal.vue
@@ -80,6 +80,7 @@
                         <span class="age-input-label" id="basic-addon1">Long Range</span>
                         <input type="text" class="form-control" aria-label="Character Name" v-model="attack.longRange"  aria-describedby="basic-addon1">
                     </div>
+										
                     <div class="mb-3 col">
                     <span class="age-input-label" id="basic-addon1">Reload</span>
                         <select
@@ -92,6 +93,31 @@
                             <option value="Major">Major Action</option>
                         </select>
                 </div>
+				<div class="row">
+  <div class="mb-3 col">
+    <span class="age-input-label" id="basic-addon1">Damage Qualities</span>
+    <input
+      type="text"
+      class="form-control"
+      aria-label="Damage Qualities"
+      placeholder="Qualities eg: Damage [[1d6]]"
+      v-model="attack.damageQualities"
+      aria-describedby="basic-addon1"
+    >
+  </div>
+
+  <div class="mb-3 col">
+    <span class="age-input-label" id="basic-addon1">Damage Flaws</span>
+    <input
+      type="text"
+      class="form-control"
+      aria-label="Damage Flaws"
+      placeholder="Flaws eg: Damage [[1d6]]"
+      v-model="attack.damageFlaws"
+      aria-describedby="basic-addon1"
+    >
+  </div>
+</div>
                 </div>
                 <div class="row" v-if="attack.weaponType === 'Spell Ranged'">
                     <div class="mb-3 col">

--- a/ageofficial/src/components/attack/CharacterAttack.vue
+++ b/ageofficial/src/components/attack/CharacterAttack.vue
@@ -57,6 +57,7 @@
         <button class="age-btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Damage
         </button>
+		
         <!-- {{ totalBonus }} <br /> -->
         <!-- {{ useModifiersStore().getDamageBonus() || 'X'}}
         {{ useModifiersStore().damageMod || 'X'}} -->

--- a/ageofficial/src/components/attack/CharacterAttack.vue
+++ b/ageofficial/src/components/attack/CharacterAttack.vue
@@ -49,10 +49,10 @@
           {{ (attackHit + trained > 0 ? `+` : '') + (attackHit + trained) }}
         </button>
       </div>
-      <div class="age-weapon-btn-container age-combat-damage" v-if="filteredDamageMods.length === 0">  
-        <button class="age-btn" @click="handlePrintDamage(modsBonus)">{{ modsBonus }}</button>
-      </div>
-      <div class="age-weapon-btn-container age-combat-damage" v-if="filteredDamageMods.length > 0">   
+      <div class="age-weapon-btn-container age-combat-damage" v-if="hasDamage && filteredDamageMods.length === 0"> 
+  <button class="age-btn" @click="handlePrintDamage(modsBonus)">{{ modsBonus }}</button>
+</div>
+      <div class="age-weapon-btn-container age-combat-damage" v-if="hasDamage && filteredDamageMods.length > 0">   
                
         <button class="age-btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Damage
@@ -155,7 +155,11 @@ const trained = computed(() => {
   }
   // return (settings.gameSystem === 'fage2e' || settings.gameSystem === 'blue rose') ? char.weaponGroups.includes(props.attack.weaponGroup) ? 0 : props.attack.weaponType === 'Natural' ? 0: -2 : 0
 });
-
+const hasDamage = computed(() => {
+  return props.attack.damage !== undefined
+    && props.attack.damage !== null
+    && String(props.attack.damage).trim() !== '';
+});
 const attackHit = computed(() => attackToHit(props.attack).value);
 const modsBonus = computed(() => {
   if(props.attack.minStr > ability.StrengthBase) return '1d6-1';

--- a/ageofficial/src/components/inventory/InventoryItem.vue
+++ b/ageofficial/src/components/inventory/InventoryItem.vue
@@ -19,6 +19,7 @@
               </button></div>
           </div>
         </div>
+		
         
       <div style="display: grid;align-items: center;grid-template-columns: 1fr;height: 100%;"></div>
       <div style="display: grid;align-items: center;grid-template-columns: 1fr;height: 100%;">
@@ -35,7 +36,14 @@
       <button type="button" class="config-btn age-icon-btn" @click="showModal = true" v-tippy="{ content: 'Edit Equipment'}">
           <font-awesome-icon :icon="['fa', 'gear']" />
       </button> 
-
+<div v-if="item.qualities || item.flaws" class="age-speel-details">
+  <div v-if="item.qualities">
+    <strong>Qualities:</strong> {{ item.qualities }}
+  </div>
+  <div v-if="item.flaws">
+    <strong>Flaws:</strong> {{ item.flaws }}
+  </div>
+</div>
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" :data-bs-target="'#collapse' + index"  aria-expanded="true" aria-controls="collapseOne"></button>
     </div>
     <div :id="'collapse'+ index" class="accordion-collapse age-accordion-collapse collapsed collapse" data-bs-parent="#age-spell-accordion">

--- a/ageofficial/src/components/inventory/InventoryItem.vue
+++ b/ageofficial/src/components/inventory/InventoryItem.vue
@@ -36,12 +36,24 @@
       <button type="button" class="config-btn age-icon-btn" @click="showModal = true" v-tippy="{ content: 'Edit Equipment'}">
           <font-awesome-icon :icon="['fa', 'gear']" />
       </button> 
-<div v-if="item.qualities || item.flaws" class="age-speel-details">
+<div
+  v-if="item.qualities || item.flaws || item.damageQualities || item.damageFlaws"
+  class="age-speel-details"
+>
   <div v-if="item.qualities">
-    <strong>Qualities:</strong> {{ item.qualities }}
+    <strong>Item Qualities:</strong> {{ item.qualities }}
   </div>
+
   <div v-if="item.flaws">
-    <strong>Flaws:</strong> {{ item.flaws }}
+    <strong>Item Flaws:</strong> {{ item.flaws }}
+  </div>
+
+  <div v-if="item.damageQualities">
+    <strong>Damage Qualities:</strong> {{ item.damageQualities }}
+  </div>
+
+  <div v-if="item.damageFlaws">
+    <strong>Damage Flaws:</strong> {{ item.damageFlaws }}
   </div>
 </div>
         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" :data-bs-target="'#collapse' + index"  aria-expanded="true" aria-controls="collapseOne"></button>

--- a/ageofficial/src/components/inventory/InventoryModal.vue
+++ b/ageofficial/src/components/inventory/InventoryModal.vue
@@ -61,7 +61,7 @@
 </div>
 
 
-            <div class="row" style="margin: 0" v-if="item.type !== 'weapon'">
+            <div class="row" style="margin: 0">
   <div class="mb-3 col">
     <span class="age-input-label" id="basic-addon1">Item Qualities</span>
     <input

--- a/ageofficial/src/components/inventory/InventoryModal.vue
+++ b/ageofficial/src/components/inventory/InventoryModal.vue
@@ -61,7 +61,7 @@
 </div>
 
 
-<div class="row" style="margin:0">
+            <div class="row" style="margin: 0" v-if="item.type !== 'weapon'">
   <div class="mb-3 col">
     <span class="age-input-label" id="basic-addon1">Item Qualities</span>
     <input
@@ -69,7 +69,7 @@
       class="form-control"
       placeholder="Qualities"
       v-model="item.qualities"
-    >
+    />
   </div>
   <div class="mb-3 col">
     <span class="age-input-label" id="basic-addon1">Item Flaws</span>
@@ -78,7 +78,7 @@
       class="form-control"
       placeholder="Flaws"
       v-model="item.flaws"
-    >
+    />
   </div>
 </div>
 
@@ -204,6 +204,30 @@
                         aria-describedby="basic-addon1" v-model="item.damage">
                   </div>
                 </div>
+				 <div class="mb-3 col">
+    <span class="age-input-label" id="basic-addon1">Damage Qualities</span>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Qualities"
+      aria-label="Damage Qualities"
+      v-model="item.damageQualities"
+      aria-describedby="basic-addon1"
+    />
+  </div>
+
+  <div class="mb-3 col">
+    <span class="age-input-label" id="basic-addon1">Damage Flaws</span>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Flaws"
+      aria-label="Damage Flaws"
+      v-model="item.damageFlaws"
+      aria-describedby="basic-addon1"
+    />
+  </div>
+</div>
                 <div class="row" style="margin:0">
                   <div class="mb-3 col" v-if="settings.gameSystem === 'mage' || settings.gameSystem === 'expanse'">
                     <span class="age-input-label" id="basic-addon1">Damage Source</span>

--- a/ageofficial/src/components/inventory/InventoryModal.vue
+++ b/ageofficial/src/components/inventory/InventoryModal.vue
@@ -59,11 +59,11 @@
     </div>
   </div>
 </div>
-</div>
+
 
 <div class="row" style="margin:0">
   <div class="mb-3 col">
-    <span class="age-input-label" id="basic-addon1">Item Qualitie </span>
+    <span class="age-input-label" id="basic-addon1">Item Qualities</span>
     <input
       type="text"
       class="form-control"

--- a/ageofficial/src/components/inventory/InventoryModal.vue
+++ b/ageofficial/src/components/inventory/InventoryModal.vue
@@ -45,14 +45,42 @@
                     </div>
                   </div>
                 </div>
-                <div class="row" style="margin:0">
-                  <div class="mb-3 col">
-                    <span class="age-input-label" id="basic-addon1">Cost</span>
-                    <div>
-                      <input type="text" class="form-control" aria-label="Quantity" v-model="item.cost"  aria-describedby="basic-addon1">
-                    </div>
-                  </div>
-                </div>
+                                 <div class="row" style="margin:0">
+  <div class="mb-3 col">
+    <span class="age-input-label" id="basic-addon1">Cost</span>
+    <div>
+      <input
+        type="text"
+        class="form-control"
+        aria-label="Cost"
+        v-model="item.cost"
+        aria-describedby="basic-addon1"
+      >
+    </div>
+  </div>
+</div>
+
+<div class="row" style="margin:0">
+  <div class="mb-3 col">
+    <span class="age-input-label" id="basic-addon1">Qualities</span>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Qualities"
+      v-model="item.qualities"
+    >
+  </div>
+  <div class="mb-3 col">
+    <span class="age-input-label" id="basic-addon1">Flaws</span>
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Flaws"
+      v-model="item.flaws"
+    >
+  </div>
+</div>
+
                 <div class="row" style="margin:0" v-if="isArmor || isShield">
 
                   <div class="mb-3 col" v-if="isArmor">

--- a/ageofficial/src/components/inventory/InventoryModal.vue
+++ b/ageofficial/src/components/inventory/InventoryModal.vue
@@ -59,10 +59,11 @@
     </div>
   </div>
 </div>
+</div>
 
 <div class="row" style="margin:0">
   <div class="mb-3 col">
-    <span class="age-input-label" id="basic-addon1">Qualities</span>
+    <span class="age-input-label" id="basic-addon1">Item Qualitie </span>
     <input
       type="text"
       class="form-control"
@@ -71,7 +72,7 @@
     >
   </div>
   <div class="mb-3 col">
-    <span class="age-input-label" id="basic-addon1">Flaws</span>
+    <span class="age-input-label" id="basic-addon1">Item Flaws</span>
     <input
       type="text"
       class="form-control"

--- a/ageofficial/src/components/inventory/InventoryModal.vue
+++ b/ageofficial/src/components/inventory/InventoryModal.vue
@@ -204,30 +204,31 @@
                         aria-describedby="basic-addon1" v-model="item.damage">
                   </div>
                 </div>
-				 <div class="mb-3 col">
-    <span class="age-input-label" id="basic-addon1">Damage Qualities</span>
-    <input
-      type="text"
-      class="form-control"
-      placeholder="Qualities"
-      aria-label="Damage Qualities"
-      v-model="item.damageQualities"
-      aria-describedby="basic-addon1"
-    />
-  </div>
+				     <div class="row" style="margin:0">
+                  <div class="mb-3 col">
+                    <span class="age-input-label" id="basic-addon1">Damage Qualities</span>
+                    <input
+                      type="text"
+                      class="form-control"
+                      placeholder="Qualities"
+                      aria-label="Damage Qualities"
+                      v-model="item.damageQualities"
+                      aria-describedby="basic-addon1"
+                    />
+                  </div>
 
-  <div class="mb-3 col">
-    <span class="age-input-label" id="basic-addon1">Damage Flaws</span>
-    <input
-      type="text"
-      class="form-control"
-      placeholder="Flaws"
-      aria-label="Damage Flaws"
-      v-model="item.damageFlaws"
-      aria-describedby="basic-addon1"
-    />
-  </div>
-</div>
+                  <div class="mb-3 col">
+                    <span class="age-input-label" id="basic-addon1">Damage Flaws</span>
+                    <input
+                      type="text"
+                      class="form-control"
+                      placeholder="Flaws"
+                      aria-label="Damage Flaws"
+                      v-model="item.damageFlaws"
+                      aria-describedby="basic-addon1"
+                    />
+                  </div>
+                </div>
                 <div class="row" style="margin:0">
                   <div class="mb-3 col" v-if="settings.gameSystem === 'mage' || settings.gameSystem === 'expanse'">
                     <span class="age-input-label" id="basic-addon1">Damage Source</span>

--- a/ageofficial/src/components/inventory/InventorySection.vue
+++ b/ageofficial/src/components/inventory/InventorySection.vue
@@ -116,7 +116,9 @@ const itemNew = ref({
   slots: '',
   name: '',
   description: '',
-  quantity: 1
+  quantity: 1,
+  qualities: '',
+  flaws: '',
 })
 function resetItem(){
   itemNew.value = {
@@ -125,7 +127,9 @@ function resetItem(){
     slots: '',
     name: '',
     description: '',
-    quantity: 1
+    quantity: 1,
+	qualities: '',
+	flaws: '',
   }
 }
 

--- a/ageofficial/src/components/magic/CharacterSpell.vue
+++ b/ageofficial/src/components/magic/CharacterSpell.vue
@@ -64,7 +64,7 @@
                 <span>{{ spell.spellType }}</span>
               <span class="age-spell-details__label">Casting Time</span>
                 <span>{{ spell.castingTime + ' Action' }}</span>
-              <span class="age-spell-details__label">{{ magicPoints }} Cost</span>
+              <span class="age-spell-details__label">{{ magicPoints }} </span>
                 <span>{{ spell.mpCost }}</span>
               <span class="age-spell-details__label">Target Number</span>
                 <span>{{ spell.targetNumber }}</span>
@@ -96,7 +96,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useSpellStore } from '@/sheet/stores/magic/magicStore';
 import { useAbilityScoreStore } from '@/sheet/stores/abilityScores/abilityScoresStore'
 import SpellModal from './SpellModal.vue';
@@ -125,8 +125,7 @@ const props = defineProps({
 
 const expanded = ref(false);
 
-const magicLabel = ref('Arcana');
-const magicPoints = ref('MP');
+
 
 const familiarity = ref(0);
 const familiarityOptions = ref([
@@ -137,20 +136,15 @@ const familiarityOptions = ref([
   { value: 8, label: 'Casually Familiar' },
   { value: 10, label: 'Slightly Familiar' }
 ]);
-switch(settings.gameSystem){
-  case 'mage':
-    magicLabel.value = 'Power';
-    if(settings.userPowerFatigue){
-      magicPoints.value = ' Power Cost';
-    } else {
-      magicPoints.value = 'PP';
-    }
-  break;
-  default:
-    magicLabel.value = 'Arcana';
-    magicPoints.value = 'MP';
-  break;
-}
+const magicLabel = computed(() =>
+  settings.gameSystem === 'mage' ? 'Power' : 'Arcana'
+);
+
+const magicPoints = computed(() => {
+  if (settings.gameSystem !== 'mage') return 'MP';
+
+  return settings.userPowerFatigue ? ' Power Cost' : 'PP';
+});
 const toggleExpand = () => {
   expanded.value = !expanded.value;
 };

--- a/ageofficial/src/components/magic/MagicSection.vue
+++ b/ageofficial/src/components/magic/MagicSection.vue
@@ -87,15 +87,9 @@ switch(settings.gameSystem){
     magicTypes.value = brArcana;
   break;
 }
-const magicLabel = ref('Arcana');
-switch(settings.gameSystem){
-  case 'mage':
-    magicLabel.value = 'Power';
-  break;
-  default:
-    magicLabel.value = 'Arcana';
-  break;
-}
+const magicLabel = computed(() =>
+  settings.gameSystem === 'mage' ? 'Power' : 'Arcana'
+);
 // Debounce delay (in milliseconds)
 const debounceDelay = 600;
 let debounceTimer;

--- a/ageofficial/src/components/magic/SpellModal.vue
+++ b/ageofficial/src/components/magic/SpellModal.vue
@@ -10,7 +10,7 @@
           <div >
             <div class="row"> 
               <div class="mb-3 col">
-                <span class="age-input-label" id="basic-addon1">{{ magicLabel }} Name</span>
+                <span class="age-input-label" id="basic-addon1">{{ spellTerminology.nameLabel }} </span>
                 <input type="text" class="form-control" placeholder="Name" aria-label="Character Name" v-model="spell.name"  aria-describedby="basic-addon1">
               </div>
               <div class="mb-3 col">
@@ -28,11 +28,11 @@
               </div>
               <div class="row">
                 <div v-if="spell.arcanaType === 'custom'" class="mb-3 col">
-                          <span class="age-input-label" id="basic-addon1">{{magicPoints}} Cost</span>
+                          <span class="age-input-label" id="basic-addon1">{{ spellTerminology.pointsLabel }} </span>
                           <input type="number" class="form-control" placeholder="Name" aria-label="Character Name" v-model="spell.mpCost"  aria-describedby="basic-addon1">
                       </div>
                   <div class="mb-3 col">
-                      <span class="age-input-label" id="basic-addon1">{{ magicLabel }} Req.</span>
+                      <span class="age-input-label" id="basic-addon1">{{ spellTerminology.requirementLabel }} </span>
                           <select
                           class="age-atk-select form-select"
                               data-testid="test-spell-weaponType-input"
@@ -89,10 +89,10 @@
                               <option value="Major">Major Action</option>
                           </select>
                   </div>
-                  <div class="mb-3 col" v-if="settings.gameSystem !== 'blue rose'">
-                      <span class="age-input-label" id="basic-addon1">Test</span>
-                      <input type="text" class="form-control" placeholder="ex. Strength(Might)" aria-label="Spell Test" v-model="spell.spellTest"  aria-describedby="basic-addon1">
-                  </div>
+                 <div class="mb-3 col" v-if="settings.gameSystem !== 'blue rose'">
+  <span class="age-input-label" id="basic-addon1">{{ spellTerminology.testLabel }}</span>
+  <input type="text" class="form-control" placeholder="ex. Strength(Might)" aria-label="Spell Test" v-model="spell.spellTest" aria-describedby="basic-addon1">
+</div>
                   <div class="mb-3 col" v-if="settings.gameSystem === 'blue rose'">
                       <span class="age-input-label" id="basic-addon1">Test</span>
                       <select
@@ -305,7 +305,35 @@ const props = defineProps({
   mode: String,
   magicLabel:String
 })
+const spellTerminology = computed(() => {
+  switch (settings.gameSystem) {
+    case 'fage1e':
+    case 'fage2e':
+    case 'mage':
+      return {
+        nameLabel: 'Spell Name',
+        requirementLabel: 'Arcana Talent Req.',
+        testLabel: 'Resistance Test',
+        pointsLabel: magicPoints.value,
+      };
 
+    case 'threefold':
+      return {
+        nameLabel: 'Spell Name',
+        requirementLabel: 'Arcana Talent Req.',
+        testLabel: 'Resistance Test',
+        pointsLabel: 'Kanna',
+      };
+
+    default:
+      return {
+        nameLabel: `${props.magicLabel} Name`,
+        requirementLabel: `${props.magicLabel} Req.`,
+        testLabel: 'Test',
+        pointsLabel: magicPoints.value,
+      };
+  }
+});
 const settings = useSettingsStore();
 const magicTypes = ref();
 const magicPoints = computed(() => settings.gameSystem === 'mage' ? settings.userPowerFatigue ? 'Power' : 'PP' : 'MP');

--- a/ageofficial/src/components/modifiers/CustomAttackModView.vue
+++ b/ageofficial/src/components/modifiers/CustomAttackModView.vue
@@ -61,21 +61,3 @@ const props = defineProps({
 const abilities = ['Accuracy', 'Communication','Constitution','Dexterity','Fighting','Intelligence','Perception','Strength','Willpower']
 const weaponTypes = ['Melee','Natural','Ranged','Spell Melee','Spell Ranged']
 </script>
-
-<style scoped>
-.custom-attack-mod {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  width: 100%;
-  align-items: start;
-}
-
-.custom-attack-mod > div {
-  flex: 1 1 150px;
-}
-
-.custom-attack-mod__damage {
-  flex: 0 0 95px;
-}
-</style>

--- a/ageofficial/src/components/modifiers/CustomAttackModView.vue
+++ b/ageofficial/src/components/modifiers/CustomAttackModView.vue
@@ -27,11 +27,28 @@
     <div v-if="mod.weaponType === 'Spell Ranged' || mod.weaponType === 'Ranged'">
         <input type="number"  class="form-control" placeholder="Long Range"  v-model="mod.longRange" />
     </div>
-    <div style="width: 75px;">
+    <div>
         <input type="text"  class="form-control" placeholder="1d6"  v-model="mod.damage" />
     </div>
+	<div>
+  <input
+    type="text"
+    class="form-control"
+    placeholder="Qualities"
+    v-model="mod.damageQualities"
+  />
+</div>
+<div>
+  <input
+    type="text"
+    class="form-control"
+    placeholder="Flaws"
+    v-model="mod.damageFlaws"
+  />
+</div>
                       
     </div>
+   
 </template>
 <script setup>
 import { ref } from 'vue';
@@ -44,3 +61,21 @@ const props = defineProps({
 const abilities = ['Accuracy', 'Communication','Constitution','Dexterity','Fighting','Intelligence','Perception','Strength','Willpower']
 const weaponTypes = ['Melee','Natural','Ranged','Spell Melee','Spell Ranged']
 </script>
+
+<style scoped>
+.custom-attack-mod {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  width: 100%;
+  align-items: start;
+}
+
+.custom-attack-mod > div {
+  flex: 1 1 150px;
+}
+
+.custom-attack-mod__damage {
+  flex: 0 0 95px;
+}
+</style>

--- a/ageofficial/src/rolltemplates/partials/header.hbs
+++ b/ageofficial/src/rolltemplates/partials/header.hbs
@@ -98,28 +98,3 @@
   {{/if}}
 </div>
 {{/if}}
-{{#if (isEqual "spellDamage" rollType)}}
-<div class="damage-header">
-  {{#if characterName}}
-    <div class="damage-header__character-name">{{characterName}} | </div>
-  {{/if}}
-  {{#if @partial-block}}
-    <div class="damage-header__group">
-      {{> @partial-block }}
-      <div class="damage-header__sub-group">
-        <div class="damage-header__title">{{title}}</div>
-        {{#if subtitle}}
-          <div class="damage-header__subtitle">{{subtitle}}</div>
-        {{/if}}
-      </div>
-    </div>
-  {{else}}
-    <div class="damage-header__sub-group">
-      <div class="damage-header__title">{{title}}</div>
-      {{#if subtitle}}
-        <div class="damage-header__subtitle">{{ capitalize subtitle}}</div>
-      {{/if}}
-    </div>
-  {{/if}}
-</div>
-{{/if}}

--- a/ageofficial/src/rolltemplates/templates/ageRoll.hbs
+++ b/ageofficial/src/rolltemplates/templates/ageRoll.hbs
@@ -1,141 +1,130 @@
 {{#> wrapper type="roll" keyValues=keyValues }}
   {{#if (isEqual "attack" rollType)}}
     {{#> header characterName=characterName title=title subtitle=subtitle}}{{/ header}}
+
     <div class="body">
       {{> rollDie dice=(getDice ../components multiplier) resultType=resultType }}
-      
+
       {{> rollComponents components=components }}
-      
 
-      {{#if keyValues}}
-        {{> keyValues keyValues=keyValues }}
-      {{/if}}
-      
       {{> rollStunt hasDuplicates=(hasDuplicates ../components multiplier) resultType=resultType dice=(getDice ../components multiplier)}}
-      <div class='roll__component component' style="width: 100%;">
-       <hr>
-      <div style="
-        display: flex;
-        justify-content: space-between;
-        font-size: 15px;
-        font-weight: bold;
-        color:rgba(0,0,0,0.87);">
-    <span>Total</span>
-    <span class=" showtip tipsy-n-right" original-title="{{> rollResults}}">
-        {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
-    </span>  
-    {{#if targetNumber}}
-    {{> spellTN total=(sumComponents ../components multiplier) spellTN=targetNumber}}
-    {{/if}}
-  </div>
-      
-    {{#if textContent}}
-      <div>
-        {{> textContent textContent=textContent }}
-      </div>
-    {{/if}}
-    {{!-- {{#if  dice=(hasDuplicates ../components multiplier)}}
-        <p>There are duplicate numbers in the dice roll.</p>
-      {{else}}
-        <p>No duplicates in the dice roll.</p>
-      {{/if}} --}}
-      </div>
-    </div>
-  {{/if}}
-    {{#if (isEqual "standard" rollType)}}
-      {{#> header characterName=characterName title=title subtitle=subtitle}}{{/ header}}
 
-      <div class="body">
-        {{> rollDie dice=(getDice ../components multiplier) resultType=resultType }}
-        {{> rollComponents components=components }}
-
-        {{#if keyValues}}
-          {{> keyValues keyValues=keyValues }}
-        {{/if}}
-        {{> rollStunt hasDuplicates=(hasDuplicates ../components multiplier) resultType=resultType dice=(getDice ../components multiplier)}}
+      <div class="roll__component component" style="width: 100%;">
         <hr>
-        {{#if targetNumber}}
-          <div class="age-roll-row">
-            <span>TN</span>
-            <span>
-                {{targetNumber}}
-            </span> 
-          </div>
-          <hr />
-        {{/if}}
+
         <div class="age-roll-row">
           <span>Total</span>
-          <span>
-              {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
-          </span>   
+          <span class="showtip tipsy-n-right" original-title="{{> rollResults}}">
+            {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
+          </span>
 
-        {{!-- {{#if  dice=(hasDuplicates ../components multiplier)}}
-          <p>There are duplicate numbers in the dice roll.</p>
-        {{else}}
-          <p>No duplicates in the dice roll.</p>
-        {{/if}} --}}
-        </div>
-        {{#unless hideSuccessText}}
           {{#if targetNumber}}
             {{> spellTN total=(sumComponents ../components multiplier) spellTN=targetNumber}}
           {{/if}}
-        {{/unless}}
+        </div>
+
+        {{#if keyValues}}
+          <hr>
+          {{> keyValues keyValues=keyValues }}
+        {{/if}}
+
         {{#if textContent}}
-          <hr />
           <div>
             {{> textContent textContent=textContent }}
           </div>
         {{/if}}
-    {{/if}}
+      </div>
+    </div>
+  {{/if}}
+
+  {{#if (isEqual "standard" rollType)}}
+    {{#> header characterName=characterName title=title subtitle=subtitle}}{{/ header}}
+
+    <div class="body">
+      {{> rollDie dice=(getDice ../components multiplier) resultType=resultType }}
+      {{> rollComponents components=components }}
+
+      {{#if keyValues}}
+        {{> keyValues keyValues=keyValues }}
+      {{/if}}
+
+      {{> rollStunt hasDuplicates=(hasDuplicates ../components multiplier) resultType=resultType dice=(getDice ../components multiplier)}}
+      <hr>
+
+      {{#if targetNumber}}
+        <div class="age-roll-row">
+          <span>TN</span>
+          <span>{{targetNumber}}</span>
+        </div>
+        <hr>
+      {{/if}}
+
+      <div class="age-roll-row">
+        <span>Total</span>
+        <span>
+          {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
+        </span>
+      </div>
+
+      {{#unless hideSuccessText}}
+        {{#if targetNumber}}
+          {{> spellTN total=(sumComponents ../components multiplier) spellTN=targetNumber}}
+        {{/if}}
+      {{/unless}}
+
+      {{#if textContent}}
+        <hr>
+        <div>
+          {{> textContent textContent=textContent }}
+        </div>
+      {{/if}}
+    </div>
+  {{/if}}
+
   {{!-- Power Fatigue Test Roll --}}
   {{#if (isEqual "powerFatigue" rollType)}}
     {{#> header characterName=characterName title=title subtitle=subtitle}}{{/ header}}
 
     <div class="body">
       {{> rollDie dice=(getDice ../components multiplier) resultType=resultType }}
+
       <div style="margin-top: 14px;">
-        <hr />
+        <hr>
+
         <div class="age-roll-row">
           <span>Total</span>
-          <span class=" showtip tipsy-n-right" original-title="{{> rollResults}}">
-              {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
+          <span class="showtip tipsy-n-right" original-title="{{> rollResults}}">
+            {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
           </span>
         </div>
+
         {{#if targetNumber}}
           {{> pfTest total=(sumComponents ../components multiplier) pfTest=targetNumber}}
         {{/if}}
-        </div>      
+      </div>
     </div>
   {{/if}}
+
   {{!-- Damage Roll --}}
   {{#if (isEqual "damage" rollType)}}
-  {{#> header characterName=characterName title=title subtitle=subtitle}}
-    {{/ header}}
+    {{#> header characterName=characterName title=title subtitle=subtitle}}{{/ header}}
 
     <div class="body">
       <div class="age-roll-row">
         <span>Total</span>
-        <span class=" showtip tipsy-n-right" original-title="{{> rollResults}}">
-            {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
+        <span class="showtip tipsy-n-right" original-title="{{> rollResults}}">
+          {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
         </span>
       </div>
-    </div>
-  {{/if}}
-  {{#if (isEqual "spellDamage" rollType)}}
 
-  {{#> header characterName=characterName title=title subtitle=subtitle}}
-    {{/ header}}
-
-    <div class="body">
-      <div class="age-roll-row">
-        <span>Total</span>
-        <span class=" showtip tipsy-n-right" original-title="{{> rollResults}}">
-            {{> rollTotal total=(sumComponents ../components multiplier) resultType=resultType}}
-        </span>
-      </div>
+      {{#if keyValues}}
+        <hr>
+        {{> keyValues keyValues=keyValues }}
+      {{/if}}
     </div>
   {{/if}}
 {{/ wrapper }}
+
 <style>
   .age-roll {
     list-style: none;
@@ -145,15 +134,17 @@
     margin: 6px 0;
     font-size: 50px;
   }
+
   .age-roll div:last-child {
     text-transform: uppercase;
-    color:#1e4e7a;
+    color: #1e4e7a;
   }
+
   .age-roll-row {
     display: flex;
     justify-content: space-between;
     font-size: 15px;
     font-weight: bold;
-    color:rgba(0,0,0,0.87);
+    color: rgba(0, 0, 0, 0.87);
   }
 </style>

--- a/ageofficial/src/sheet/stores/attack/attackStore.ts
+++ b/ageofficial/src/sheet/stores/attack/attackStore.ts
@@ -17,6 +17,8 @@ interface Attack {
   description: string;
   ability:string;
   damage:string;
+  damageQualities?: string;
+  damageFlaws?: string;
   weaponGroup:string;
   weaponGroupAbility:string;
   shortRange:number | null;
@@ -129,16 +131,16 @@ export const useAttackStore = defineStore('attacks', () => {
     if( powerFatiguePenalty.value > 0 && settings.userPowerFatigue){
       components.push({ label: 'Power Fatigue', value: powerFatiguePenalty.value * -1 });
     }
-   await rollToChat({
-  characterName: useMetaStore().name,
-  title: weapon.name,
-  rollType: 'attack',
-  keyValues: {
-    'Damage Qualities': weapon.damageQualities || '',
-    'Damage Flaws': weapon.damageFlaws || '',
-  },
-  components
-});
+    await rollToChat({
+      characterName: useMetaStore().name,
+      title: weapon.name,
+      rollType: 'attack',
+      keyValues: {
+        'Damage Qualities': weapon.damageQualities || '',
+        'Damage Flaws': weapon.damageFlaws || '',
+      },
+      components
+    });
   };
   const printAttackDetails = async (weapon: any, bonus?:number,focus?:any) => {
     if (!weapon) return;
@@ -198,16 +200,16 @@ export const useAttackStore = defineStore('attacks', () => {
     components.push(      
       { label: 'Modifier', value: isNaN(modifier.value) ? 0 : modifier.value }, // Ensure modifier is a number
     );
-	await rollToChat({
-	characterName: useMetaStore().name,
-	title: attack.name,
-	rollType: 'damage',
-	keyValues: {
-    'Damage Qualities': attack.damageQualities || '',
-    'Damage Flaws': attack.damageFlaws || '',
-  },
-  components
-});
+    await rollToChat({
+      characterName: useMetaStore().name,
+      title: attack.name,
+      rollType: 'damage',
+      keyValues: {
+        'Damage Qualities': attack.damageQualities || '',
+        'Damage Flaws': attack.damageFlaws || '',
+      },
+      components
+    });
   };
   const setCurrentAttack = (_id: string) => {
     const attack = attacks.value.find((item) => item._id === _id);

--- a/ageofficial/src/sheet/stores/attack/attackStore.ts
+++ b/ageofficial/src/sheet/stores/attack/attackStore.ts
@@ -129,19 +129,28 @@ export const useAttackStore = defineStore('attacks', () => {
     if( powerFatiguePenalty.value > 0 && settings.userPowerFatigue){
       components.push({ label: 'Power Fatigue', value: powerFatiguePenalty.value * -1 });
     }
-    await rollToChat({
-      characterName: useMetaStore().name,
-      title: weapon.name,
-      rollType:'attack',
-      components
-    });
+   await rollToChat({
+  characterName: useMetaStore().name,
+  title: weapon.name,
+  rollType: 'attack',
+  keyValues: {
+    'Damage Qualities': weapon.damageQualities || '',
+    'Damage Flaws': weapon.damageFlaws || '',
+  },
+  components
+});
   };
   const printAttackDetails = async (weapon: any, bonus?:number,focus?:any) => {
     if (!weapon) return;
     await sendToChat({
       title: weapon.name,
       subtitle: weapon.weaponType,
-      traits: ['Weapon Type: ' + weapon.weaponType, 'Weapon Group: ' + weapon.weaponGroup],
+      traits: [
+  'Weapon Type: ' + weapon.weaponType,
+  weapon.weaponGroup ? 'Weapon Group: ' + weapon.weaponGroup : '',
+  weapon.damageQualities ? 'Damage Qualities: ' + weapon.damageQualities : '',
+  weapon.damageFlaws ? 'Damage Flaws: ' + weapon.damageFlaws : '',
+].filter(Boolean),
       description: weapon.description,
     });
   }
@@ -189,18 +198,24 @@ export const useAttackStore = defineStore('attacks', () => {
     components.push(      
       { label: 'Modifier', value: isNaN(modifier.value) ? 0 : modifier.value }, // Ensure modifier is a number
     );
-    await rollToChat({
-      characterName: useMetaStore().name,
-      title: attack.name,
-      rollType:'damage',
-      components
-    });
-  }
+	await rollToChat({
+	characterName: useMetaStore().name,
+	title: attack.name,
+	rollType: 'damage',
+	keyValues: {
+    'Damage Qualities': attack.damageQualities || '',
+    'Damage Flaws': attack.damageFlaws || '',
+  },
+  components
+});
+  };
   const setCurrentAttack = (_id: string) => {
     const attack = attacks.value.find((item) => item._id === _id);
     if (!attack) return;
     selectedAttack = attack;
   };
+
+  
   /*
    * Firebase is not able to store Arrays, so the items array must be stored as an object indexed by the _id
    * */

--- a/ageofficial/src/sheet/stores/character/characterQualitiesStore.ts
+++ b/ageofficial/src/sheet/stores/character/characterQualitiesStore.ts
@@ -89,6 +89,8 @@ export const useItemStore = defineStore('quality', ()=>{
         Object.assign(newMod,{
           name: mod.name,
           damage: mod.damage,
+		  damageQualities: mod.damageQualities,
+		  damageFlaws: mod.damageFlaws,
           weaponType: mod.weaponType,
           weaponGroupAbility: mod.weaponGroupAbility,
         })

--- a/ageofficial/src/sheet/stores/inventory/inventoryStore.ts
+++ b/ageofficial/src/sheet/stores/inventory/inventoryStore.ts
@@ -22,6 +22,8 @@ export type Item = {
   description: string;
   quantity: number;
   cost:string;
+  qualities?: string;
+  flaws?: string;
 };
 
 export type Weapon = Item & {
@@ -172,9 +174,9 @@ export const useInventoryStore = defineStore('inventory', () => {
       description: newItem ? newItem.description : '',
       type: newItem ? newItem.type : '',
       quantity: newItem ? newItem.quantity : '',
-      cost: newItem.cost || '',
-	  qualities: newItem ? newItem.qualities : '',
-	flaws: newItem ? newItem.flaws : '',
+      cost: newItem?.cost ?? '',
+      qualities: newItem?.qualities ?? '',
+      flaws: newItem?.flaws ?? '',
     };
     if(newItem.type === 'weapon'){
       Object.assign(emptyItem,{
@@ -187,6 +189,8 @@ export const useInventoryStore = defineStore('inventory', () => {
 		shortRange:newItem ? newItem.shortRange : '',
         longRange:newItem ? newItem.longRange : '',
         reload:newItem ? newItem.reload : '',
+        damageQualities: newItem?.damageQualities ?? '',
+        damageFlaws: newItem?.damageFlaws ?? '',
         minStr: newItem.minStr || 0,
         configurable:true,
       })

--- a/ageofficial/src/sheet/stores/inventory/inventoryStore.ts
+++ b/ageofficial/src/sheet/stores/inventory/inventoryStore.ts
@@ -36,6 +36,8 @@ export type Weapon = Item & {
   shortRange?:number | null;
   longRange?:number | null;
   reload?:string;
+  damageQualities?: string;
+  damageFlaws?: string;
   configurable:boolean
   minStr?: number;
   damageType?:string;
@@ -180,6 +182,8 @@ export const useInventoryStore = defineStore('inventory', () => {
         ability: newItem ? newItem.ability : '',
         weaponGroup: newItem ? newItem.weaponGroup : '',
         weaponGroupAbility:newItem ? newItem.weaponGroupAbility : '',
+		damageQualities: newItem ? newItem.damageQualities : '',
+        damageFlaws: newItem ? newItem.damageFlaws : '',
         shortRange:newItem ? newItem.shortRange : '',
         longRange:newItem ? newItem.longRange : '',
         reload:newItem ? newItem.reload : '',

--- a/ageofficial/src/sheet/stores/inventory/inventoryStore.ts
+++ b/ageofficial/src/sheet/stores/inventory/inventoryStore.ts
@@ -172,7 +172,9 @@ export const useInventoryStore = defineStore('inventory', () => {
       description: newItem ? newItem.description : '',
       type: newItem ? newItem.type : '',
       quantity: newItem ? newItem.quantity : '',
-      cost: newItem.cost || ''
+      cost: newItem.cost || '',
+	  qualities: newItem ? newItem.qualities : '',
+	flaws: newItem ? newItem.flaws : '',
     };
     if(newItem.type === 'weapon'){
       Object.assign(emptyItem,{
@@ -182,9 +184,7 @@ export const useInventoryStore = defineStore('inventory', () => {
         ability: newItem ? newItem.ability : '',
         weaponGroup: newItem ? newItem.weaponGroup : '',
         weaponGroupAbility:newItem ? newItem.weaponGroupAbility : '',
-		damageQualities: newItem ? newItem.damageQualities : '',
-        damageFlaws: newItem ? newItem.damageFlaws : '',
-        shortRange:newItem ? newItem.shortRange : '',
+		shortRange:newItem ? newItem.shortRange : '',
         longRange:newItem ? newItem.longRange : '',
         reload:newItem ? newItem.reload : '',
         minStr: newItem.minStr || 0,

--- a/ageofficial/src/sheet/stores/magic/magicStore.ts
+++ b/ageofficial/src/sheet/stores/magic/magicStore.ts
@@ -143,7 +143,7 @@ export const useSpellStore = defineStore('spells', () => {
     await rollToChat({
       characterName: useMetaStore().name,
       title: spell.name,
-      rollType:'spellDamage',
+      rollType: 'damage',
       components
     });
   }


### PR DESCRIPTION
## Submission Checklist
- [x] The Pull Request title contains the **short name** of the sheet being submitted.
- [x] The Pull Request title states the **type of change** being submitted (New/Update/Bugfix/etc.).
- [x] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

## New Sheet Checklist
Not applicable. This is an update to the existing AGE official sheet.

# Changes / Description (optional)

Updates Fantasy AGE and Modern AGE spell/power modal labels to better match Compendium terminology:
- `Arcana Name` is now `Spell Name`
- `Arcana Req.` is now `Arcana Talent Req.`
- `Test` is now `Resistance Test`

Blue Rose labels are unchanged.

Also changes AGE magic terminology labels to use reactive computed values, preventing stale Modern AGE `Power` labels from appearing after switching systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Damage Qualities" and "Damage Flaws" fields for attacks and weapons
  * Added "Item Qualities" and "Item Flaws" fields for inventory items
  * Magic terminology labels now update dynamically based on game system settings

* **Improvements**
  * Damage UI displays conditionally only when applicable
  * Spell modal labels automatically adjust based on active game system
  * Roll template display restructured for clearer presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->