### PR TITLE
sheet/feat/ageofficial

### DIFF
--- a/ageofficial/src/App.vue
+++ b/ageofficial/src/App.vue
@@ -225,8 +225,16 @@
       class="age-import-overlay"
       @click.self="cancelImport"
     >
-      <div class="age-import-modal">
-        <h3>Import {{ importCharacterName }}</h3>
+      <div
+        ref="importModalRef"
+        class="age-import-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="age-import-title"
+        tabindex="-1"
+        @keydown="onImportKeydown"
+      >
+        <h3 id="age-import-title">Import {{ importCharacterName }}</h3>
         <p>
           Choose which sections to import, then add them to the sheet or
           overwrite the existing data.
@@ -285,7 +293,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 
 import { useAgeSheetStore } from "./sheet/stores";
 import PCView from "./views/PCView.vue";
@@ -367,9 +375,14 @@ const importCharacterName = computed(() =>
   initValues.character?.name ? `“${initValues.character.name}”` : "Character"
 );
 
+const importModalRef = ref(null);
+// The element focused before the modal opened, so focus can be restored on close.
+let importTrigger = null;
+
 const openImportModal = () => {
   // Start with every section selected.
   selectedSections.value = IMPORT_SECTIONS.map((s) => s.key);
+  importTrigger = document.activeElement;
   importModalOpen.value = true;
 };
 const confirmImport = (mode) => {
@@ -384,6 +397,47 @@ const confirmImport = (mode) => {
 const cancelImport = () => {
   importModalOpen.value = false;
 };
+
+// Selector for the focusable controls inside the modal (used for the focus trap).
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const onImportKeydown = (event) => {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    cancelImport();
+    return;
+  }
+  if (event.key !== "Tab") return;
+  const modal = importModalRef.value;
+  if (!modal) return;
+  const focusable = Array.from(
+    modal.querySelectorAll(FOCUSABLE_SELECTOR)
+  ).filter((el) => el.offsetParent !== null || el === modal);
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  // Wrap focus around the modal's edges so Tab never escapes to the page behind.
+  if (event.shiftKey && (active === first || active === modal)) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+};
+
+// Move focus into the modal when it opens and restore it to the trigger on close.
+watch(importModalOpen, async (open) => {
+  if (open) {
+    await nextTick();
+    importModalRef.value?.focus();
+  } else if (importTrigger && typeof importTrigger.focus === "function") {
+    importTrigger.focus();
+    importTrigger = null;
+  }
+});
 </script>
 
 <style scoped lang="scss">

--- a/ageofficial/src/App.vue
+++ b/ageofficial/src/App.vue
@@ -200,6 +200,75 @@
 
   <CompendiumDropHandler />
 
+  <!-- Legacy import trigger. Not teleported: it is position:fixed, and a
+       v-tippy directive inside a Teleport corrupts the Teleport's patch. -->
+  <div class="age-import-panel" v-if="settings.allowImport">
+    <button
+      class="age-import-btn"
+      type="button"
+      v-tippy="{ content: 'Import', placement: 'left', delay: [300, 0] }"
+      @click="openImportModal"
+    >
+      <span
+        class="age-import-icon"
+        :class="importIconClass"
+        aria-hidden="true"
+      ></span>
+      <span class="age-visually-hidden">Import</span>
+    </button>
+  </div>
+
+  <!-- Import modal: pick sections, then append or overwrite. -->
+  <Teleport to="body">
+    <div
+      v-if="importModalOpen"
+      class="age-import-overlay"
+      @click.self="cancelImport"
+    >
+      <div class="age-import-modal">
+        <h3>Import {{ importCharacterName }}</h3>
+        <p>
+          Choose which sections to import, then add them to the sheet or
+          overwrite the existing data.
+        </p>
+        <div class="age-import-sections">
+          <label
+            v-for="section in importSections"
+            :key="section.key"
+            class="age-import-section"
+          >
+            <input
+              type="checkbox"
+              :value="section.key"
+              v-model="selectedSections"
+            />
+            <span>{{ section.label }}</span>
+          </label>
+        </div>
+        <div class="age-import-actions">
+          <button
+            type="button"
+            :disabled="!selectedSections.length"
+            @click="confirmImport('append')"
+          >
+            Append
+          </button>
+          <button
+            type="button"
+            class="age-import-overwrite"
+            :disabled="!selectedSections.length"
+            @click="confirmImport('overwrite')"
+          >
+            Overwrite
+          </button>
+          <button type="button" class="age-import-cancel" @click="cancelImport">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+
   <!-- Character Notes -->
   <Teleport to="body">
     <SidebarSection ref="sidebarRef" :className="'age-notes'">
@@ -237,6 +306,8 @@ import {
   loadLegacyAbilityScores,
   loadLegacyCharacterDetails,
   loadLegacyGroupings,
+  importLegacyCharacter,
+  IMPORT_SECTIONS,
 } from "@/utility/legacyAdapter";
 const showModal = ref(false);
 
@@ -281,9 +352,186 @@ if (!settings.incomeMode) {
 loadLegacyAbilityScores(initValues.character?.attributes);
 loadLegacyCharacterDetails(initValues.character?.attributes);
 loadLegacyGroupings(initValues.character?.attributes);
+
+// Modern AGE / Expanse use a direct background-image icon; Fantasy AGE / Blue
+// Rose use a mask-image icon tinted by the button color.
+const importIconClass = computed(() =>
+  settings.gameSystem === "mage" || settings.gameSystem === "expanse"
+    ? "age-import-icon--bg"
+    : "age-import-icon--mask"
+);
+const importSections = IMPORT_SECTIONS;
+const importModalOpen = ref(false);
+const selectedSections = ref(IMPORT_SECTIONS.map((s) => s.key));
+const importCharacterName = computed(() =>
+  initValues.character?.name ? `“${initValues.character.name}”` : "Character"
+);
+
+const openImportModal = () => {
+  // Start with every section selected.
+  selectedSections.value = IMPORT_SECTIONS.map((s) => s.key);
+  importModalOpen.value = true;
+};
+const confirmImport = (mode) => {
+  importLegacyCharacter(
+    initValues.character?.attributes,
+    mode,
+    selectedSections.value,
+    initValues.character?.name
+  );
+  importModalOpen.value = false;
+};
+const cancelImport = () => {
+  importModalOpen.value = false;
+};
 </script>
 
 <style scoped lang="scss">
+.age-import-panel {
+  position: fixed;
+  right: 0;
+  bottom: 16px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  /* Mostly tucked off the right edge (thin grab sliver) so it doesn't block
+     play; slides fully out on hover or keyboard focus (focus-within covers
+     tabbing to any child). */
+  transform: translateX(calc(100% - 12px));
+  transition: transform 0.25s ease;
+
+  &:hover,
+  &:focus-within {
+    transform: translateX(0);
+  }
+}
+.age-import-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 9px;
+  background: var(--theme-primary, #1e4e7a);
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-right: none;
+  border-radius: 6px 0 0 6px;
+  box-shadow: -2px 2px 8px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+}
+.age-import-icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+}
+/* Fantasy AGE / Blue Rose: mask-image tinted by the button color. */
+.age-import-icon--mask {
+  background-color: #fff;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: contain;
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="%23fff" d="M373.563 18.406c-15.616-.167-27.91 4.622-32.563 14.75-22.778 49.605-48.743 87.14-79.094 117.28 3.047 1.015 6.046 2.29 8.938 3.783 12.987 6.708 25.268 17.78 35.312 30.843 10.044 13.062 17.85 28.114 20.78 43.5.746 3.908 1.16 7.885 1.158 11.843 38.97-24.36 85.058-41.223 140.875-51.312 14.91-2.697 23.652-28.632 21.405-58.656l-35.156-1 30.56-24.813c-4.148-14.507-11.013-28.754-21.155-40.72-15.528-18.314-36.43-31.376-56.72-38.686L381.94 40.812l2.812-21.5c-3.875-.55-7.61-.87-11.188-.907zM246.938 166.562c-1.063.052-2.06.226-3 .47-11.976 10.254-24.61 19.597-37.938 28.28.842.33 1.67.667 2.5 1.032 14.123 6.192 27.438 17.145 38.47 30.625 13.356 16.322 23.62 36.94 25.624 57.75 10.334-10.367 21.24-19.943 32.844-28.72 4.096-6.555 4.93-14.468 3.125-23.938-2.184-11.46-8.642-24.43-17.25-35.625-8.61-11.194-19.38-20.622-29.063-25.625-6.052-3.126-11.154-4.45-15.313-4.25zm-61.907 43.282c-1.385.053-2.69.27-3.968.562-37 20.762-79.088 37.985-127.312 56 .574.042 1.14.093 1.72.156 10.627 1.156 21.076 5.008 31.155 10.875L124.313 261 108.5 293.72c5.995 5.432 11.803 11.477 17.344 18 20.76 24.434 37.964 55.865 47.094 88.092.002.01-.003.022 0 .032 2.98 10.508 5.11 20.916 6.312 31 20.99-48.438 44.38-89.26 72.344-123 7.3-21.48-2.186-48.408-19.063-69.03-9.44-11.538-20.976-20.718-31.53-25.345-5.936-2.604-11.27-3.808-15.97-3.626zm141.626 54.844c-7.31 5.05-14.462 10.51-21.437 16.312 39.16 9.26 60.953 35.722 80.655 62.156 10.464 14.04 20.598 28.11 33.125 40.688 24.19 9.147 43.17 6.38 63.906-14.938-92.165-27.78-96.11-92.61-156.25-104.22zM48.594 284.906c-10.873.225-18.26 5.755-23.344 16.594-5.81 12.387-7.114 32.47.438 57.063 5.75 18.73 16.52 37.718 28.75 51.625 12.23 13.906 25.9 22.076 35.374 22.406h.032c3.717.13 6.553-.682 8.812-2.75l-.187-.188 2.093-2.094c.793-1.168 1.52-2.548 2.187-4.187 2.81-6.9 3.28-18.552-1.844-33-6.885-19.417-19.12-31.932-33.375-34.78l-22.968-4.564 19.813-12.5 38.47-24.186c-16.65-16.822-34.55-27.607-49.376-29.22-1.7-.184-3.323-.25-4.876-.218zm236.25 5.406l-24.53 25.375c100.442 17.878 55.45 141.005 159.31 176.188l-24.78-57.28c32.766 16.15 67.39 22.623 97.72 12.03-135.77-41.948-96.32-126.983-207.72-156.313zm-169.47 38.22l-25.968 16.343c13.18 8.5 23.21 22.565 29.125 39.25 2.57 7.244 4.133 14.205 4.75 20.78l23.44-23.374c-8.08-19.19-19.035-37.566-31.345-53zm38.376 72.374l-42.063 42-.156-.156c-4.255 3.942-9.456 6.765-15.186 7.938 23.268 14.873 44.644 19.346 56.812 9.562 4.26-3.426 7.043-8.36 8.47-14.406-.41-12.684-2.602-26.615-6.657-40.906-.382-1.346-.806-2.686-1.22-4.032z"/></svg>');
+}
+/* Modern AGE / Expanse: direct (white) background-image icon. */
+.age-import-icon--bg {
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="%23fff" d="M394.8 30.88l-65 65.03 86.3 86.29 65.1-65-86.4-86.32zm-6.3 36.04l17 17-12.8 12.72-17-17 12.8-12.72zm-82.8 30.4l-11.3 11.28 109 108.9 11.3-11.2-109-108.98zM263.3 103L23.4 342.9v60.5l85.2 85.2h60.5l240-239.9L263.3 103zm164.9 3.6l16.9 17-12.8 12.6-16.9-17 12.8-12.6z"/></svg>');
+}
+.age-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.age-import-sections {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 16px;
+  margin-bottom: 18px;
+}
+.age-import-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #222;
+  cursor: pointer;
+
+  input {
+    cursor: pointer;
+  }
+}
+.age-import-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+.age-import-modal {
+  width: min(90vw, 380px);
+  padding: 20px 24px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  color: #222;
+
+  h3 {
+    margin: 0 0 8px;
+  }
+  p {
+    margin: 0 0 18px;
+    font-size: 14px;
+    line-height: 1.4;
+  }
+}
+.age-import-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+
+  button {
+    padding: 8px 16px;
+    font-weight: 600;
+    color: #fff;
+    background: var(--theme-primary, #1e4e7a);
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+
+    &:hover {
+      filter: brightness(1.08);
+    }
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+      filter: none;
+    }
+  }
+  .age-import-overwrite {
+    background: #a3341f;
+  }
+  .age-import-cancel {
+    color: #333;
+    background: #e2e2e2;
+  }
+}
 .sys-logo {
   height: auto;
   margin-left: 10px;

--- a/ageofficial/src/components/abilities/AbilitiesView.vue
+++ b/ageofficial/src/components/abilities/AbilitiesView.vue
@@ -131,7 +131,7 @@
   </Teleport>
 </template>
 <script setup>
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { useBioStore } from "@/sheet/stores/bio/bioStore";
 import { useAbilityScoreStore } from "@/sheet/stores/abilityScores/abilityScoresStore";
 import AbilitiesModal from "@/components/abilities/AbilitiesModal.vue";
@@ -142,7 +142,7 @@ import { useItemStore } from "@/sheet/stores/character/characterQualitiesStore";
 import SidebarSection from "@/components/SidebarSection.vue";
 import { abilityMods } from "@/sheet/stores/modifiersCheck/abilities";
 import { abilities } from "./abilities";
-const { abilityScores, rollAbilityCheck } = useAbilityScoreStore();
+const { rollAbilityCheck } = useAbilityScoreStore();
 const abilitiesInfo = abilities;
 // const abilityScoresArray = ref(
 //   Object.entries(abilityScores).map(([label, abilityScore]) => ({ ...abilityScore, label })),
@@ -152,28 +152,24 @@ const showModal = ref(false);
 const showRerollModal = ref(false);
 const showAbilityCheckModal = ref(false);
 const selectedAbility = ref("");
-const abilityScoresArray = ref([]);
 const settings = useSettingsStore();
 const focus = useAbilityFocusesStore();
 const quality = useItemStore();
 const abilityMod = abilityMods;
-// Function to generate the abilityScoresArray
-function generateAbilityScoresArray() {
-  return Object.entries(useAbilityScoreStore().abilityScores).map(
+
+// Computed so external updates (e.g. legacy import) reflect immediately,
+// instead of a one-time snapshot refreshed only on modal close.
+const abilityScoresArray = computed(() =>
+  Object.entries(useAbilityScoreStore().abilityScores).map(
     ([label, abilityScore]) => ({
       ...abilityScore,
       label,
     })
-  );
-}
+  )
+);
 
-// Initialize the abilityScoresArray
-abilityScoresArray.value = generateAbilityScoresArray();
-
-// Function to handle modal close and refresh abilityScoresArray
 function closeModal() {
   showModal.value = false;
-  abilityScoresArray.value = generateAbilityScoresArray();
 }
 function closeCheckModal() {
   showAbilityCheckModal.value = false;

--- a/ageofficial/src/sheet/stores/settings/settingsStore.ts
+++ b/ageofficial/src/sheet/stores/settings/settingsStore.ts
@@ -45,6 +45,7 @@ export type SettingsHydrate = {
     incomeMode: string;
     showAfterMastery?: boolean;
     theme?: string;
+    allowImport?: boolean;
   };
 };
 
@@ -85,6 +86,7 @@ export const useSettingsStore = defineStore("settings", () => {
   const incomeMode = ref("");
   const showAfterMastery = ref(false);
   const theme = ref("basic");
+  const allowImport = ref(false);
 
   const dehydrate = () => {
     return {
@@ -125,6 +127,7 @@ export const useSettingsStore = defineStore("settings", () => {
         incomeMode: incomeMode.value,
         showAfterMastery: showAfterMastery.value,
         theme: theme.value,
+        allowImport: allowImport.value,
       },
     };
   };
@@ -180,6 +183,7 @@ export const useSettingsStore = defineStore("settings", () => {
     showAfterMastery.value =
       hydrateStore.settings.showAfterMastery ?? showAfterMastery.value;
     theme.value = hydrateStore.settings.theme || theme.value;
+    allowImport.value = hydrateStore.settings.allowImport ?? allowImport.value;
   };
 
   return {
@@ -218,6 +222,7 @@ export const useSettingsStore = defineStore("settings", () => {
     optionalMovements,
     showAfterMastery,
     theme,
+    allowImport,
     incomeMode,
     dehydrate,
     hydrate,

--- a/ageofficial/src/utility/legacyAdapter.spec.ts
+++ b/ageofficial/src/utility/legacyAdapter.spec.ts
@@ -1,0 +1,293 @@
+import { setActivePinia, createPinia } from "pinia";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { importLegacyCharacter } from "./legacyAdapter";
+import { useAbilityScoreStore } from "@/sheet/stores/abilityScores/abilityScoresStore";
+import { useCharacterStore } from "@/sheet/stores/character/characterStore";
+import { useBioStore } from "@/sheet/stores/bio/bioStore";
+import { useInventoryStore } from "@/sheet/stores/inventory/inventoryStore";
+import { useItemStore } from "@/sheet/stores/character/characterQualitiesStore";
+import { useSpellStore } from "@/sheet/stores/magic/magicStore";
+import { useSettingsStore } from "@/sheet/stores/settings/settingsStore";
+import { useMetaStore } from "@/sheet/stores/meta/metaStore";
+
+// Representative flat legacy attributes (only the keys the importer reads).
+const bjordson: Record<string, any> = {
+  game: "fantasy-age-core",
+  class: "Warrior",
+  health: 49,
+  level: "4",
+  // xp lives on the structured character section (optional/nullable).
+  character: { character: { xp: 6000 } },
+  race: "Orc",
+  "social-class": "Middle",
+  background: "Soldier",
+  specialization1: "Berserker",
+  "specialization1-degree": "Novice",
+  accuracy: "1",
+  communication: "0",
+  constitution: "4",
+  dexterity: "2",
+  fighting: "4",
+  strength: "2",
+  willpower: "2",
+  perception: "1",
+  gender: "Male",
+  height: "6'11\"",
+  weight: "285",
+  eyes: "Brown",
+  skin: "Ruddy Green",
+  hair: "Black",
+  armor: "8",
+  speed_value: 9,
+  "weapon-groups": "Brawling, Axes, Heavy Blades, Light Blades",
+  character_notes: "When growing up...",
+  "repeating_talent_-Nc5Gpm71VXxr2x2sSbb_powername": "Dual Weapon",
+  "repeating_talent_-Nc5Gpm71VXxr2x2sSbb_talentdegree": "3",
+  "repeating_power_-Nc5GbtAKm6rqAhZ4xbQ_powername": "Berserker Rage",
+  "repeating_power_-Nc5GbtAKm6rqAhZ4xbQ_shortpowerdescription": "+2 Damage",
+  "repeating_strength-focus_-Nc5HZZoW22N-SBt9NkT_focusname": "Intimidation",
+  "repeating_strength-focus_-Nc5OzuuqLCtaMfriieM_focusname": "Jumping",
+  "repeating_constitution-focus_-Nc5Hnp16bZL8n5zG9Ks_focusname": "Stamina",
+  "repeating_perception-focus_-NeZkrJ6bFtya9lqIqPK_focusname": "search",
+  "repeating_attack-list_-Nc5IkCVdDFbVhRJyqry_attack-name": "Battle Axe1",
+  "repeating_attack-list_-Nc5IkCVdDFbVhRJyqry_attack-damage": "2d6+2",
+  "repeating_attack-list_-NdD7NA0sk4p-WcApyQA_attack-name": "Rage Battle Axe 1",
+  "repeating_attack-list_-NdD7NA0sk4p-WcApyQA_attack-damage": "3d6+4",
+  "repeating_equipment_-Nc5K3HQBCcLtrsxn-yU_equipment-name": "Heavy Shield",
+  "repeating_equipment_-Nc5K3HQBCcLtrsxn-yU_equipment-description": "+3 Defense",
+  "repeating_money_-Nc5KRQEVgBcfoVoQ8Am_moneyamount": "6",
+  "repeating_money_-Nc5KRQEVgBcfoVoQ8Am_moneyname": "GP",
+  "repeating_money_-Nc5KYfTaXZqaa0AyNt2_moneyname": "CP",
+  "repeating_money_-Nc5KYfTaXZqaa0AyNt2_moneyamount": "50",
+};
+
+const mav: Record<string, any> = {
+  game: "fantasy-age-core",
+  class: "Mage",
+  level: "4",
+  race: "Halfling",
+  "social-class": "Upper",
+  background: "Scholar",
+  specialization1: "Necromancer",
+  accuracy: "1",
+  communication: "3",
+  constitution: "1",
+  dexterity: "3",
+  intelligence: "3",
+  perception: "2",
+  willpower: "4",
+  health: "32",
+  mana: "34",
+  "base-speed": "11",
+  "repeating_spell_-NbCJThmzjDjzgQJZzRE_spell-name": "Revival",
+  "repeating_spell_-NbCJThmzjDjzgQJZzRE_spell-school": "Healing",
+  "repeating_spell_-NbCJThmzjDjzgQJZzRE_spell-mp-cost": "6",
+  "repeating_spell_-NbCJThmzjDjzgQJZzRE_spell-tn": "14",
+  "repeating_spell_-NbCJThmzjDjzgQJZzRE_spell-type": "utility",
+  "repeating_spell_-NlES75wSLKtAVKfPKPZ_spell-name": "Healing Aura",
+  "repeating_spell_-NlES75wSLKtAVKfPKPZ_spell-mp-cost": "2-8",
+  "repeating_dexterity-focus_-Nc2ltxz7MLElRfLmMzS_focusname": "Traps",
+  "repeating_attack-list_-Nc4z2E8RCvIwVVFfF5E_attack-name": "Crossbow",
+  "repeating_attack-list_-Nc4z2E8RCvIwVVFfF5E_range": "30",
+  "repeating_attack-list_-Nc4z2E8RCvIwVVFfF5E_reload": "major",
+  "repeating_attack-list_-Nc4z2E8RCvIwVVFfF5E_attack-damage": "2d6+1",
+  // Reversed money row: code lives in `moneyamount`.
+  "repeating_money_-NbzTg90Tgn1oSAdYlEb_moneyname": "10",
+  "repeating_money_-NbzTg90Tgn1oSAdYlEb_moneyamount": "G",
+};
+
+describe("importLegacyCharacter (flat legacy format)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.spyOn(console, "table").mockImplementation(() => {});
+    vi.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  it("imports Bjordson (warrior)", () => {
+    importLegacyCharacter(bjordson, "append", undefined, "Bjordson");
+    const ability = useAbilityScoreStore();
+    const char = useCharacterStore();
+    const bio = useBioStore();
+    const inventory = useInventoryStore();
+    const qualities = useItemStore();
+    const settings = useSettingsStore();
+
+    // Renamed, and speed defaults to the AGE base (no base-speed in the data).
+    expect(useMetaStore().name).toBe("Bjordson");
+    expect(char.speed).toBe(10);
+
+    expect(ability.FightingBase).toBe(4);
+    expect(ability.ConstitutionBase).toBe(4);
+    expect(ability.StrengthBase).toBe(2);
+    expect(ability.AccuracyBase).toBe(1);
+
+    expect(char.health).toBe(49);
+    expect(char.armor).toBe(8);
+    expect(char.weaponGroups).toBe(
+      JSON.stringify(["Brawling", "Axes", "Heavy Blades", "Light Blades"])
+    );
+    expect(bio.level).toBe(4);
+    expect(char.xp).toBe(6000); // from structured xp, not derived from level
+
+    expect(bio.ancestry).toBe("Orc");
+    expect(bio.profession).toBe("Warrior");
+    expect(bio.background).toBe("Soldier");
+    expect(bio.socialClass).toBe("Middle");
+    expect(bio.sex).toBe("Male");
+    expect(bio.detailsHistory).toContain("When growing up");
+
+    expect(settings.gameSystem).toBe("fage2e");
+
+    // Quality items: Specialization + Ancestry + Class + Talent + Power.
+    const byType = (t: string) => qualities.items.filter((i) => i.type === t);
+    expect(byType("Specialization").map((i) => i.name)).toContain("Berserker");
+    expect(byType("Ancestry").map((i) => i.name)).toContain("Orc");
+    expect(byType("Class").map((i) => i.name)).toContain("Warrior");
+    expect(byType("Talent").map((i) => i.name)).toContain("Dual Weapon");
+    expect(byType("Special Feature").map((i) => i.name)).toContain(
+      "Berserker Rage"
+    );
+    expect(byType("Ability Focus").map((i) => i.name)).toEqual(
+      expect.arrayContaining(["Intimidation", "Jumping", "Stamina", "search"])
+    );
+
+    // Attacks became inventory weapons.
+    const weapons = inventory.items.filter((i) => i.type === "weapon");
+    expect(weapons.map((w) => w.name)).toEqual(
+      expect.arrayContaining(["Battle Axe1", "Rage Battle Axe 1"])
+    );
+
+    // Money (GP/CP correctly mapped).
+    expect(inventory.cash.gold).toBe(6);
+    expect(inventory.cash.copper).toBe(50);
+  });
+
+  it("imports Mav (mage) with spells and reversed money", () => {
+    importLegacyCharacter(mav);
+    const ability = useAbilityScoreStore();
+    const char = useCharacterStore();
+    const spells = useSpellStore();
+    const inventory = useInventoryStore();
+
+    expect(ability.WillpowerBase).toBe(4);
+    expect(ability.IntelligenceBase).toBe(3);
+    expect(char.health).toBe(32);
+    expect(char.magic).toBe(34);
+
+    // Mage caster → Arcana shown; base-speed drives char.speed (11 + Dex).
+    expect(useSettingsStore().showArcana).toBe(true);
+    expect(char.speed).toBe(11);
+
+    const revival = spells.spells.find((s) => s.name === "Revival");
+    expect(revival).toBeTruthy();
+    expect(revival?.arcanaType).toBe("Healing");
+    expect(revival?.mpCost).toBe(6);
+    expect(revival?.targetNumber).toBe(14);
+
+    // "2-8" mp range keeps the first number.
+    const aura = spells.spells.find((s) => s.name === "Healing Aura");
+    expect(aura?.mpCost).toBe(2);
+
+    // Reversed money row: amount "G" is the code, name "10" is the number.
+    expect(inventory.cash.gold).toBe(10);
+
+    // Ranged attack → weapon with parsed range.
+    const crossbow = inventory.items.find((i) => i.name === "Crossbow") as any;
+    expect(crossbow?.type).toBe("weapon");
+    expect(crossbow?.shortRange).toBe(30);
+  });
+
+  it("overwrite clears the previous character first", () => {
+    importLegacyCharacter(bjordson);
+    let inventory = useInventoryStore();
+    expect(inventory.cash.gold).toBe(6);
+    expect(inventory.items.some((i) => i.name === "Battle Axe1")).toBe(true);
+
+    importLegacyCharacter(mav, "overwrite");
+    inventory = useInventoryStore();
+    const ability = useAbilityScoreStore();
+    const char = useCharacterStore();
+    // Bjordson's data is gone; Mav's is present.
+    expect(inventory.items.some((i) => i.name === "Battle Axe1")).toBe(false);
+    expect(inventory.items.some((i) => i.name === "Crossbow")).toBe(true);
+    expect(inventory.cash.gold).toBe(10); // Mav's reversed gold, not Bjordson's 6
+    expect(ability.FightingBase).toBe(0); // Mav has no Fighting
+    expect(ability.WillpowerBase).toBe(4);
+    // healthMax / magicMax stay at default (Roll20 omits them); the player
+    // enters the real max themselves.
+    expect(char.healthMax).toBe(0);
+    expect(char.magicMax).toBe(0);
+  });
+
+  it("append keeps the previous character's data", () => {
+    importLegacyCharacter(bjordson);
+    importLegacyCharacter(mav, "append");
+    const inventory = useInventoryStore();
+    expect(inventory.items.some((i) => i.name === "Battle Axe1")).toBe(true);
+    expect(inventory.items.some((i) => i.name === "Crossbow")).toBe(true);
+  });
+
+  it("does not clear the sheet when the blob has no legacy data", () => {
+    importLegacyCharacter(bjordson); // populate the sheet
+    const ability = useAbilityScoreStore();
+    const inventory = useInventoryStore();
+    expect(ability.FightingBase).toBe(4);
+    expect(inventory.cash.gold).toBe(6);
+
+    // Empty / non-legacy blob with overwrite must NOT wipe the sheet.
+    importLegacyCharacter({}, "overwrite");
+    expect(ability.FightingBase).toBe(4);
+    expect(inventory.cash.gold).toBe(6);
+  });
+
+  it("imports only the selected sections", () => {
+    importLegacyCharacter(bjordson, "append", ["abilities"]);
+    const ability = useAbilityScoreStore();
+    const bio = useBioStore();
+    const inventory = useInventoryStore();
+    // abilities imported...
+    expect(ability.FightingBase).toBe(4);
+    // ...but nothing else (bio, currency untouched)
+    expect(bio.ancestry).toBe("");
+    expect(inventory.cash.gold).toBe(0);
+  });
+
+  it("overwrite only clears the selected sections", () => {
+    importLegacyCharacter(bjordson); // full import
+    const inventory = useInventoryStore();
+    expect(inventory.cash.gold).toBe(6);
+    expect(inventory.items.some((i) => i.name === "Battle Axe1")).toBe(true);
+
+    // Overwrite only currency with an empty-money character.
+    importLegacyCharacter({ race: "X", level: "1" }, "overwrite", ["currency"]);
+    expect(inventory.cash.gold).toBe(0); // currency cleared
+    // weapons untouched (equipment section not selected)
+    expect(inventory.items.some((i) => i.name === "Battle Axe1")).toBe(true);
+  });
+
+  it("parses messy money formats (combined, spelled-out, split range)", () => {
+    importLegacyCharacter({
+      race: "Test",
+      level: "1",
+      // combined code+number in one field, no name
+      "repeating_money_-Aaaaaaaaaaaaaaaaaaa_moneyamount": "18g",
+      // spelled out, split across fields
+      "repeating_money_-Bbbbbbbbbbbbbbbbbbb_moneyname": "silver",
+      "repeating_money_-Bbbbbbbbbbbbbbbbbbb_moneyamount": "28",
+      // short / long range on a thrown weapon
+      "repeating_attack-list_-Ccccccccccccccccccc_attack-name": "Throwing Axe",
+      "repeating_attack-list_-Ccccccccccccccccccc_range": "4 / 6",
+      "repeating_attack-list_-Ccccccccccccccccccc_attack-damage": "1d6+2",
+    });
+    const inventory = useInventoryStore();
+    expect(inventory.cash.gold).toBe(18);
+    expect(inventory.cash.silver).toBe(28);
+    const axe = inventory.items.find((i) => i.name === "Throwing Axe") as any;
+    expect(axe.shortRange).toBe(4);
+    expect(axe.longRange).toBe(6);
+  });
+});

--- a/ageofficial/src/utility/legacyAdapter.ts
+++ b/ageofficial/src/utility/legacyAdapter.ts
@@ -35,6 +35,24 @@ type LegacyAttributes = Record<string, any>;
 type GroupedRepeating = Record<string, Array<Record<string, any>>>;
 
 /*
+ * All diagnostic console output in this module is gated behind `logMode` so it
+ * never runs in production (per the repo's dead-code policy). Flip to `true`
+ * during development to see the raw legacy blob and the import change report.
+ * Route every console call through these helpers rather than calling `console`
+ * directly.
+ */
+const logMode: boolean = false;
+const log = (...args: any[]) => {
+  if (logMode) console.log(...args);
+};
+const logWarn = (...args: any[]) => {
+  if (logMode) console.warn(...args);
+};
+const logInfo = (...args: any[]) => {
+  if (logMode) console.info(...args);
+};
+
+/*
  * Roll20 stores repeating rows as flat keys shaped
  *   repeating_<section>_<rowId>_<field>
  * where <section> and <field> may contain hyphens (e.g. `attack-list`,
@@ -70,7 +88,7 @@ export function groupRepeating(attributes: LegacyAttributes): GroupedRepeating {
 
 export function loadLegacyAbilityScores(attributes: LegacyAttributes) {
   if (!attributes) return;
-  console.log({
+  log({
     LegacyAbilities: {
       accuracy: attributes.accuracy,
       communication: attributes.communication,
@@ -99,12 +117,12 @@ export function loadLegacyCharacterDetails(attributes: LegacyAttributes) {
     armor: attributes.armor,
     weaponGroups: attributes["weapon-groups"],
   };
-  console.log({ LegacyRawAttributes: attributes, LegacyInfo: legacyInfo });
+  log({ LegacyRawAttributes: attributes, LegacyInfo: legacyInfo });
 }
 
 export function loadLegacyGroupings(attributes: LegacyAttributes) {
   if (!attributes) return;
-  console.log({ LegacyGroupings: groupRepeating(attributes) });
+  log({ LegacyGroupings: groupRepeating(attributes) });
 }
 
 /* -------------------------------------------------------------------------- */
@@ -178,11 +196,17 @@ export function importLegacyCharacterFlat(attributes: LegacyAttributes) {
   // (the already-computed total) would double-count Dexterity. Default to the
   // AGE base of 10 when absent, so Speed isn't just the Dexterity value.
   const baseSpeed = toInt(attributes["base-speed"]);
-  char.speed = baseSpeed != null ? baseSpeed : 10;
+  if (baseSpeed != null) {
+    char.speed = baseSpeed;
+  } else if (!char.speed) {
+    // Only default to the AGE base of 10 when Speed is unset, so an append
+    // import doesn't clobber an existing value the user already has.
+    char.speed = 10;
+  }
 
   // XP lives on the structured character section and is optional (may be null).
   // It is not derived from level — the real value is used when present.
-  const xp = attributes.character?.character?.xp;
+  const xp = toInt(attributes.character?.character?.xp);
   if (xp != null) char.xp = xp;
 
   // Legacy stores weapon groups as a comma string (sometimes with a trailing
@@ -285,7 +309,10 @@ export const legacyCurrency = (money: Array<Record<string, any>>) => {
     if (letters.startsWith("g")) key = "gold";
     else if (letters.startsWith("s")) key = "silver";
     else if (letters.startsWith("c")) key = "copper";
-    if (key) inventory.cash[key] = amount;
+    // Accumulate: legacy sheets often have several rows of the same
+    // denomination, and append mode should add to existing cash, not replace it.
+    // Overwrite mode resets denominations first via clearSection("currency").
+    if (key) inventory.cash[key] = (inventory.cash[key] || 0) + amount;
   });
 };
 
@@ -382,8 +409,10 @@ export const legacyAttackWeapons = (attacks: Array<Record<string, any>>) => {
   const inventory = useInventoryStore();
   attacks.forEach((atk) => {
     if (!atk["attack-name"]) return;
-    const ranged = !!atk.range;
     const { shortRange, longRange } = parseRange(atk.range);
+    // Legacy rows use placeholder ranges like "0" or "-" for melee weapons;
+    // both are truthy strings, so classify from the parsed short range instead.
+    const ranged = shortRange != null && shortRange > 0;
     inventory.addItem({
       name: atk["attack-name"],
       description: "",
@@ -500,6 +529,7 @@ function diffStates(
 }
 
 function logImportReport(report: ImportReport) {
+  if (!logMode) return report;
   const { overwritten, added, cleared } = report;
   console.groupCollapsed(
     `📋 Legacy Import Report — ${overwritten.length} overwritten, ${added.length} added, ${cleared.length} cleared`
@@ -606,8 +636,10 @@ function clearSection(key: ImportSectionKey) {
       bio.profession = "";
       bio.background = "";
       bio.socialClass = "";
+      // Legacy `gender` is imported into bio.sex only (see importLegacyBioFlat),
+      // so bio.gender is left alone here — clearing it would delete a user value
+      // that the import never rewrites.
       bio.sex = "";
-      bio.gender = "";
       bio.height = "";
       bio.weight = "";
       bio.eyes = "";
@@ -621,7 +653,10 @@ function clearSection(key: ImportSectionKey) {
       break;
     }
     case "settings":
-      // Re-applying settings is sufficient; nothing to clear.
+      // gameSystem and incomeMode are always re-applied by importLegacySettingsFlat,
+      // but showArcana is only ever turned on there, so it must be reset here or a
+      // non-caster legacy character would leave the Arcana section visible.
+      useSettingsStore().showArcana = false;
       break;
     case "talents":
       removeQualitiesByType(["Talent", "Special Feature"]);
@@ -704,7 +739,7 @@ export function importLegacyCharacter(
   // Guard: never clear/overwrite the sheet when there's no legacy data to
   // import (e.g. the character blob hasn't loaded yet).
   if (!attributes || !isLegacyData(attributes)) {
-    console.warn(
+    logWarn(
       "⚠️ Legacy import skipped: no legacy character data found in the blob."
     );
     return;
@@ -714,13 +749,17 @@ export function importLegacyCharacter(
   ) as ImportSectionKey[];
 
   const sheet = useAgeSheetStore();
-  const before = sheet.dehydrateStore();
+  // The before/after snapshots and diff only feed the dev-only import report,
+  // so skip that work entirely unless logging is on.
+  const before = logMode ? sheet.dehydrateStore() : null;
   const grouped = groupRepeating(attributes);
 
   if (mode === "overwrite") selected.forEach((key) => clearSection(key));
   selected.forEach((key) => applySection(key, attributes, grouped, name));
 
-  const after = sheet.dehydrateStore();
-  logImportReport(diffStates(before, after));
-  console.info("✅ Legacy import complete");
+  if (logMode) {
+    const after = sheet.dehydrateStore();
+    logImportReport(diffStates(before, after));
+  }
+  logInfo("✅ Legacy import complete");
 }

--- a/ageofficial/src/utility/legacyAdapter.ts
+++ b/ageofficial/src/utility/legacyAdapter.ts
@@ -1,228 +1,726 @@
 /**
- * FUTURE FEATURE — Legacy Sheet Migration
+ * Legacy Sheet Migration
  *
- * This module is intended to migrate character data from the old Roll20 sheet
- * format (repeating_* attributes) into the Beacon SDK store. It is not yet
- * active. All function bodies are currently commented out.
+ * Maps a legacy Roll20 character (`initValues.character.attributes`) into the
+ * Beacon SDK Pinia stores.
  *
- * Do NOT import or call these functions from the live sheet until the migration
- * logic is fully implemented and tested. Track progress in CLAUDE.md under
- * "Planned Features".
+ * The real legacy data lives in the FLAT attributes — top-level scalars
+ * (`level`, `health`, `race`, `accuracy`…) and `repeating_*` rows (talents,
+ * powers, spells, attacks, equipment, money, focuses). The nested structured
+ * sections (`character.character`, `bio.bio`, `abilityScores.abilityScores`…)
+ * in a legacy export are just the new sheet's empty dehydrated defaults, so
+ * they are ignored when flat data is present and only used as a fallback for an
+ * already-migrated character.
+ *
+ * `importLegacyCharacter(attributes)` is the Import button action. It snapshots
+ * the sheet, imports, snapshots again, and logs a change report.
+ *
+ * The `loadLegacy*` functions are on-load inspectors that only log — wired in
+ * `App.vue` so the raw data is visible in the console during development.
  */
-import { useAbilityScoreStore } from "@/sheet/stores/abilityScores/abilityScoresStore";
+import {
+  useAbilityScoreStore,
+  type AbilityScore,
+} from "@/sheet/stores/abilityScores/abilityScoresStore";
 import { useCharacterStore } from "@/sheet/stores/character/characterStore";
 import { useBioStore } from "@/sheet/stores/bio/bioStore";
 import { useInventoryStore } from "@/sheet/stores/inventory/inventoryStore";
 import { useItemStore } from "@/sheet/stores/character/characterQualitiesStore";
-import { ref } from "vue";
 import { useSpellStore } from "@/sheet/stores/magic/magicStore";
-import { at } from "lodash";
+import { useSettingsStore } from "@/sheet/stores/settings/settingsStore";
+import { useMetaStore } from "@/sheet/stores/meta/metaStore";
+import { useAgeSheetStore } from "@/sheet/stores";
 
-export interface MoneyAdapted {
-  _id: string;
-  moneyname: string;
-  moneyamount: number;
-}
+type LegacyAttributes = Record<string, any>;
+type GroupedRepeating = Record<string, Array<Record<string, any>>>;
 
-// export function loadLegacyAbilityScores(attributes: { [key: string]: string }) {
-// export function loadLegacyAbilityScores(attributes: { [key: string]: string }){
-//     // debugger
-//     const abilityMap: { [key: string]: string } = {
-//         accuracy: 'AccuracyBase',
-//         communications: 'CommunicationsBase',
-//         constitution: 'ConstitutionBase',
-//         dexterity: 'DexterityBase',
-//         fighting: 'FightingBase',
-//         intelligence: 'IntelligenceBase',
-//         perception: 'PerceptionBase',
-//         strength: 'StrengthBase',
-//         willpower: 'WillpowerBase',
-//     };
-//     // debugger
-//     Object.keys(attributes).forEach(key => {
+/*
+ * Roll20 stores repeating rows as flat keys shaped
+ *   repeating_<section>_<rowId>_<field>
+ * where <section> and <field> may contain hyphens (e.g. `attack-list`,
+ * `strength-focus`, `equipment-name`) and <rowId> is a leading-dash id of 20
+ * characters that may itself contain `-`/`_` (e.g. `-Nc5HZZoW22N-SBt9NkT`).
+ * A lazy section match plus a fixed-width row id keeps hyphenated sections and
+ * ids from being mis-split.
+ */
+const REPEATING_RE = /^repeating_(.+?)_(-[A-Za-z0-9_-]{19})_(.+)$/;
 
-//         if (abilityMap[key]) {
-//             const value = parseInt(attributes[key], 0);
-//             if (!isNaN(value)) {
-//                 useAbilityScoreStore().AccuracyBase =  parseInt(attributes[key], 0);
-//             }
-//         }
-//     });
-// };
-
-export function loadLegacyAbilityScores(attributes: { [key: string]: string }) {
-  const abilityMap: { [key: string]: string } = {
-    accuracy: "AccuracyBase",
-    communications: "CommunicationsBase",
-    constitution: "ConstitutionBase",
-    dexterity: "DexterityBase",
-    fighting: "FightingBase",
-    intelligence: "IntelligenceBase",
-    perception: "PerceptionBase",
-    strength: "StrengthBase",
-    willpower: "WillpowerBase",
-  };
-
-  const abilityStore = useAbilityScoreStore(); // Get the store instance once
-  const legacyAbilities = { ...abilityStore };
-  if (!attributes) return;
-  Object.keys(attributes).forEach((key) => {
-    if (abilityMap[key]) {
-      const value = parseInt(attributes[key], 0);
-      if (!isNaN(value)) {
-        const mappedKey = abilityMap[key];
-        (legacyAbilities as any)[mappedKey] = value;
-      }
-    }
-  });
-  console.log({ LegacyAbilities: legacyAbilities });
-}
-
-export function loadLegacyCharacterDetails(attributes: { [key: string]: any }) {
-  const char = useCharacterStore();
-  const bio = useBioStore();
-  if (!attributes) return;
-
-  const legacyChar = {
-    level: attributes?.level,
-    mp: attributes?.magic,
-    hp: attributes?.health,
-    socialClass: attributes["social-class"],
-    background: attributes?.background,
-    ancestry: attributes,
-    sex: attributes?.gender,
-    height: attributes?.height,
-    weight: attributes?.weight,
-    skin: attributes?.skin,
-    eyes: attributes?.eyes,
-    hair: attributes?.hair,
-  };
-  console.log({ LegacyRawAttributes: attributes, LegacyInfo: legacyChar });
-  //Primary Details
-  // char.levelSet(parseInt(attributes?.level, 0));
-  // char.magic = Number(attributes?.magic);
-  // char.health = Number(attributes?.health);
-  // bio.socialClass = attributes['social-class'];
-  // bio.background = attributes?.background;
-  // bio.ancestry = attributes?.race
-
-  // //Background
-  // bio.sex = attributes?.gender;
-  // bio.height = attributes?.height;
-  // bio.weight = attributes?.weight;
-  // bio.skin = attributes?.skin;
-  // bio.eyes = attributes?.eyes;
-  // bio.skin = attributes?.skin;
-  // bio.hair = attributes?.hair;
-}
-
-export function loadLegacyGroupings(attributes: { [key: string]: any }) {
-  const data = {
-    /* the example object */
-  };
-
-  const grouped: any = {};
-  if (!attributes) return;
+/* Groups all `repeating_*` keys into `{ [section]: [{ _id, ...fields }] }`. */
+export function groupRepeating(attributes: LegacyAttributes): GroupedRepeating {
+  const grouped: GroupedRepeating = {};
+  if (!attributes) return grouped;
   Object.entries(attributes).forEach(([key, value]) => {
-    const match = key.match(/repeating_(\w+)_-(\w+)_([\w-]+)/);
-    if (match) {
-      const [_, type, id, property] = match;
-      if (!grouped[type]) grouped[type] = [];
-      let item = grouped[type].find((obj: any) => obj._id === id);
-      if (!item) {
-        item = { _id: id };
-        grouped[type].push(item);
-      }
-      item[property] = value;
+    const match = key.match(REPEATING_RE);
+    if (!match) return;
+    const [, section, id, property] = match;
+    if (!grouped[section]) grouped[section] = [];
+    let row = grouped[section].find((obj) => obj._id === id);
+    if (!row) {
+      row = { _id: id };
+      grouped[section].push(row);
     }
+    row[property] = value;
   });
-  // // Talents
-  // if(grouped.talent){
-  //     legacyTalents(grouped.talent);
-  // }
-  // // Ancestry & Class Powers
-  // // Arcana Powers
-  // if(grouped.spell){
-  //     legacyArcana(grouped.spell);
-  // }
-  // // Ability Focus
-  // // Favored Stunts
-  // // Inventory
-  // if(grouped.equipment){
-  //     legacyInventory(grouped.equipment)
-  // }
-  // // Currency & Resources
-  // if(grouped.money){
-  // legacyCurrency(grouped.money)
-  // }
-  console.log({ LegacyGroupings: grouped });
+  return grouped;
 }
 
-export const legacyCurrency = (money: any) => {
-  console.log({ LegacyMoney: money });
-  // const inventory = useInventoryStore();
-  // money.forEach(m => {
-  //     switch(m.moneyname){
-  //         case 'CP':
-  //             inventory.cash.copper = m.moneyamount;
-  //         break;
-  //         case 'SP':
-  //             inventory.cash.silver = m.moneyamount;
-  //         break;
-  //         case 'GP':
-  //             inventory.cash.gold = m.moneyamount;
-  //         break
-  //     }
-  // })
+/* -------------------------------------------------------------------------- */
+/* On-load inspectors (log only — no store writes)                            */
+/* -------------------------------------------------------------------------- */
+
+export function loadLegacyAbilityScores(attributes: LegacyAttributes) {
+  if (!attributes) return;
+  console.log({
+    LegacyAbilities: {
+      accuracy: attributes.accuracy,
+      communication: attributes.communication,
+      constitution: attributes.constitution,
+      dexterity: attributes.dexterity,
+      fighting: attributes.fighting,
+      intelligence: attributes.intelligence,
+      perception: attributes.perception,
+      strength: attributes.strength,
+      willpower: attributes.willpower,
+    },
+  });
+}
+
+export function loadLegacyCharacterDetails(attributes: LegacyAttributes) {
+  if (!attributes) return;
+  const legacyInfo = {
+    level: attributes.level,
+    class: attributes.class,
+    race: attributes.race,
+    background: attributes.background,
+    socialClass: attributes["social-class"],
+    specialization: attributes.specialization1,
+    health: attributes.health,
+    mana: attributes.mana,
+    armor: attributes.armor,
+    weaponGroups: attributes["weapon-groups"],
+  };
+  console.log({ LegacyRawAttributes: attributes, LegacyInfo: legacyInfo });
+}
+
+export function loadLegacyGroupings(attributes: LegacyAttributes) {
+  if (!attributes) return;
+  console.log({ LegacyGroupings: groupRepeating(attributes) });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Flat scalar importers                                                      */
+/* -------------------------------------------------------------------------- */
+
+const toInt = (value: any): number | undefined => {
+  const n = parseInt(value, 10);
+  return Number.isNaN(n) ? undefined : n;
 };
 
-export const legacyTalents = (talents: any[]) => {
+const ABILITY_KEYS: Record<string, AbilityScore> = {
+  accuracy: "Accuracy",
+  communication: "Communication",
+  constitution: "Constitution",
+  dexterity: "Dexterity",
+  fighting: "Fighting",
+  intelligence: "Intelligence",
+  perception: "Perception",
+  strength: "Strength",
+  willpower: "Willpower",
+};
+
+export function importLegacyAbilityScores(attributes: LegacyAttributes) {
+  const abilityStore = useAbilityScoreStore();
+  Object.entries(ABILITY_KEYS).forEach(([flatKey, ability]) => {
+    const value = toInt(attributes[flatKey]);
+    if (value != null) {
+      (abilityStore as any)[`${ability}Base`] = value;
+    }
+  });
+}
+
+const GAME_SYSTEM_MAP: Record<string, string> = {
+  "fantasy-age-core": "fage2e",
+  "fantasy-age": "fage1e",
+  "blue-rose": "blue rose",
+  "modern-age": "mage",
+  "the-expanse": "expanse",
+};
+
+export function importLegacySettingsFlat(attributes: LegacyAttributes) {
+  const settings = useSettingsStore();
+  const system = GAME_SYSTEM_MAP[attributes.game] || "fage2e";
+  settings.gameSystem = system as any;
+  settings.incomeMode =
+    system === "fage1e" || system === "fage2e" ? "currency" : "recources";
+
+  // Casters (Mage class, or anyone with spells) get the Arcana/Powers section shown.
+  const isCaster =
+    attributes.class === "Mage" ||
+    Object.keys(attributes).some((key) => key.startsWith("repeating_spell_"));
+  if (isCaster) settings.showArcana = true;
+}
+
+export function importLegacyCharacterFlat(attributes: LegacyAttributes) {
+  const char = useCharacterStore();
+
+  // Only the current health/magic are imported. healthMax / magicMax are
+  // missing from the legacy export (a Roll20 export bug), so they are left at
+  // their default — the player enters the real max themselves.
+  const health = toInt(attributes.health);
+  if (health != null) char.health = health;
+  const mana = toInt(attributes.mana ?? attributes.magic);
+  if (mana != null) char.magic = mana;
+
+  const armor = toInt(attributes.armor);
+  if (armor != null) char.armor = armor;
+  // char.speed is the AGE *base* speed; the sheet adds Dexterity (and armor
+  // penalty) on top. Legacy `base-speed` is that base — using `speed_value`
+  // (the already-computed total) would double-count Dexterity. Default to the
+  // AGE base of 10 when absent, so Speed isn't just the Dexterity value.
+  const baseSpeed = toInt(attributes["base-speed"]);
+  char.speed = baseSpeed != null ? baseSpeed : 10;
+
+  // XP lives on the structured character section and is optional (may be null).
+  // It is not derived from level — the real value is used when present.
+  const xp = attributes.character?.character?.xp;
+  if (xp != null) char.xp = xp;
+
+  // Legacy stores weapon groups as a comma string (sometimes with a trailing
+  // "and"); the store expects a JSON array string (e.g. '["Axes","Blades"]').
+  const groups = attributes["weapon-groups"];
+  if (groups) {
+    const list = String(groups)
+      .split(",")
+      .map((g) => g.trim().replace(/^and\s+/i, "").trim())
+      .filter(Boolean);
+    if (list.length) char.weaponGroups = JSON.stringify(list);
+  }
+}
+
+export function importLegacyBioFlat(attributes: LegacyAttributes) {
+  const bio = useBioStore();
+  const level = toInt(attributes.level);
+  if (level) bio.level = level;
+  if (attributes.race) bio.ancestry = attributes.race;
+  if (attributes.class) bio.profession = attributes.class;
+  if (attributes.background) bio.background = attributes.background;
+  if (attributes["social-class"]) bio.socialClass = attributes["social-class"];
+  if (attributes.gender) bio.sex = attributes.gender;
+  if (attributes.height) bio.height = attributes.height;
+  if (attributes.weight) bio.weight = attributes.weight;
+  if (attributes.eyes) bio.eyes = attributes.eyes;
+  if (attributes.skin) bio.skin = attributes.skin;
+  if (attributes.hair) bio.hair = attributes.hair;
+  if (attributes.character_notes) bio.detailsHistory = attributes.character_notes;
+  if (attributes.goals) bio.goalsTies = attributes.goals;
+  if (attributes.relationships) bio.relationships = attributes.relationships;
+  // age is a free-text field in legacy ("A lady never tells"); only import numbers.
+  const age = toInt(attributes.age);
+  if (age != null) bio.age = age;
+}
+
+/* Maps the flat `specialization1`/`specialization2` slots to Specialization
+ * quality items (a character can have two). */
+export function importLegacySpecialization(attributes: LegacyAttributes) {
   const qualities = useItemStore();
-  // talents.forEach(talent => {
-  //     const talentDegree = ref('novice');
-  //     switch(talent.talentdegree){
-  //         case '2':
-  //             talentDegree.value = 'expert';
-  //         break;
-  //         case '3':
-  //             talentDegree.value = 'master';
-  //         break;
-  //     }
-  //     qualities.addItem({
-  //         type:'Talent',
-  //         name: talent.powername,
-  //         description:talent.talentdescription,
-  //         qualityLevel:talentDegree.value,
-  //         qualityNovice:talent.talent1description,
-  //         qualityExpert:talent.talent2description,
-  //         qualityMaster:talent.talent3description
-  //     });
-  // });
+  [1, 2].forEach((slot) => {
+    const name = attributes[`specialization${slot}`];
+    if (!name) return;
+    const degree = String(
+      attributes[`specialization${slot}-degree`] || ""
+    ).toLowerCase();
+    let qualityLevel = "novice";
+    if (degree === "2" || degree === "expert") qualityLevel = "expert";
+    if (degree === "3" || degree === "master") qualityLevel = "master";
+    qualities.addItem({
+      type: "Specialization",
+      name,
+      description: "",
+      qualityLevel,
+      modifiers: [],
+    });
+  });
+}
+
+/*
+ * Ancestry (`race`) and Class become quality items. A slash/comma-delimited
+ * value (e.g. "Half-Orc/Human") splits into one item per value.
+ */
+export function importLegacyAncestryClass(attributes: LegacyAttributes) {
+  const qualities = useItemStore();
+  const addQualities = (value: string, type: "Ancestry" | "Class") => {
+    if (!value) return;
+    String(value)
+      .split(/[/,]/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .forEach((name) => {
+        qualities.addItem({ type, name, description: "", modifiers: [] });
+      });
+  };
+  addQualities(attributes.race, "Ancestry");
+  addQualities(attributes.class, "Class");
+}
+
+/* -------------------------------------------------------------------------- */
+/* Grouped repeating-row importers                                            */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * Legacy money rows are wildly inconsistent: `moneyname`/`moneyamount` may hold
+ * the code and number in either order ("GP"+"6", "10"+"G"), spell it out
+ * ("gold"+"20"), or cram both into one field ("18g", no name). Combine both
+ * fields, then pull the number and the currency letter out independently.
+ */
+export const legacyCurrency = (money: Array<Record<string, any>>) => {
+  if (!money?.length) return;
+  const inventory = useInventoryStore();
+  money.forEach((m) => {
+    const combined = `${m.moneyname ?? ""} ${m.moneyamount ?? ""}`;
+    const numMatch = combined.match(/\d+/);
+    if (!numMatch) return;
+    const amount = Number(numMatch[0]);
+    const letters = combined.toLowerCase().replace(/[^a-z]/g, "");
+    let key: "gold" | "silver" | "copper" | null = null;
+    if (letters.startsWith("g")) key = "gold";
+    else if (letters.startsWith("s")) key = "silver";
+    else if (letters.startsWith("c")) key = "copper";
+    if (key) inventory.cash[key] = amount;
+  });
 };
 
-export const legacyInventory = (inventory: any[]) => {
+export const legacyTalents = (talents: Array<Record<string, any>>) => {
+  if (!talents?.length) return;
+  const qualities = useItemStore();
+  talents.forEach((talent) => {
+    const name = talent.powername || talent.talentdescription;
+    if (!name) return;
+    let qualityLevel = "novice";
+    if (talent.talentdegree === "2") qualityLevel = "expert";
+    if (talent.talentdegree === "3") qualityLevel = "master";
+    qualities.addItem({
+      type: "Talent",
+      name,
+      description: talent.talentdescription || "",
+      qualityLevel,
+      qualityNovice: talent.talent1description || "",
+      qualityExpert: talent.talent2description || "",
+      qualityMaster: talent.talent3description || "",
+      modifiers: [],
+    });
+  });
+};
+
+/* `repeating_power_` holds class powers and custom stunt powers. */
+export const legacyPowers = (powers: Array<Record<string, any>>) => {
+  if (!powers?.length) return;
+  const qualities = useItemStore();
+  powers.forEach((power) => {
+    const name = power.powername || power.powertype;
+    if (!name) return;
+    qualities.addItem({
+      type: "Special Feature",
+      name,
+      description: power.fullpowerdescription || power.shortpowerdescription || "",
+      modifiers: [],
+    });
+  });
+};
+
+export const legacyFocuses = (
+  focuses: Array<Record<string, any>>,
+  ability: string
+) => {
+  if (!focuses?.length) return;
+  const qualities = useItemStore();
+  focuses.forEach((focus) => {
+    if (!focus.focusname) return;
+    qualities.addItem({
+      type: "Ability Focus",
+      name: focus.focusname,
+      description: focus.focusdescription || "",
+      ability,
+      focus: true,
+      doubleFocus: false,
+      modifiers: [],
+    });
+  });
+};
+
+export const legacyInventory = (inventory: Array<Record<string, any>>) => {
+  if (!inventory?.length) return;
   const inventoryStore = useInventoryStore();
-  // inventory.forEach(item => {
-  //     console.log(item)
-  //     inventoryStore.addItem({
-  //         name:item['equipment-name'],
-  //         description:item['equipment-description'],
-  //         type:'item'
-  //     });
-  // });
+  inventory.forEach((item) => {
+    const name = item["equipment-name"];
+    if (!name && !item["equipment-description"]) return;
+    inventoryStore.addItem({
+      name: name || "",
+      description: item["equipment-description"] || "",
+      type: "item",
+      quantity: toInt(item["equipment-quantity"]) || 1,
+    });
+  });
 };
-export const legacyArcana = (arcana: any[]) => {
+
+/*
+ * Legacy attacks imply possession of the weapon (a "Longsword" attack means the
+ * character owns a longsword), so each `attack-list` row becomes an inventory
+ * weapon. A `range` marks it ranged.
+ */
+/* Range may be "26", "16 yards", or "4 / 6" (short / long). */
+const parseRange = (raw: any): { shortRange: number | null; longRange: number | null } => {
+  const nums = raw ? String(raw).match(/\d+/g) : null;
+  if (!nums) return { shortRange: null, longRange: null };
+  return {
+    shortRange: Number(nums[0]),
+    longRange: nums[1] != null ? Number(nums[1]) : null,
+  };
+};
+
+export const legacyAttackWeapons = (attacks: Array<Record<string, any>>) => {
+  if (!attacks?.length) return;
+  const inventory = useInventoryStore();
+  attacks.forEach((atk) => {
+    if (!atk["attack-name"]) return;
+    const ranged = !!atk.range;
+    const { shortRange, longRange } = parseRange(atk.range);
+    inventory.addItem({
+      name: atk["attack-name"],
+      description: "",
+      type: "weapon",
+      quantity: 1,
+      damage: atk["attack-damage"] || "",
+      weaponType: ranged ? "Ranged" : "Melee",
+      weaponGroupAbility: "",
+      shortRange,
+      longRange,
+      reload: atk.reload || "",
+    });
+  });
+};
+
+export const legacyArcana = (arcana: Array<Record<string, any>>) => {
+  if (!arcana?.length) return;
   const magic = useSpellStore();
-  // arcana.forEach(spell => {
-  //     magic.addSpell({
-  //         name:spell['spell-name'] || '',
-  //         description:spell['full-spell-description'] || '',
-  //         arcanaType: spell['spell-school'] || '',
-  //         requirements:spell['spell-requirements'] || 'Novice',
-  //         mpCost:spell['spell-mp-cost'] || 0,
-  //         shortDescription: spell['short-spell-description'] || '',
-  //         castingTime:spell['spell-cast-time'] || '',
-  //         targetNumber:spell['spell-tn'] || 0,
-  //     });
-  // });
+  arcana.forEach((spell) => {
+    if (!spell["spell-name"]) return;
+    magic.addSpell({
+      name: spell["spell-name"],
+      description: spell["full-spell-description"] || "",
+      arcanaType: spell["spell-school"] || "",
+      requirements: spell["spell-requirements"] || "Novice",
+      // mp cost may be a range like "2-8"; keep the first number.
+      mpCost: toInt(spell["spell-mp-cost"]) || 0,
+      shortDescription: spell["short-spell-description"] || "",
+      spellType: spell["spell-type"] || "",
+      castingTime: spell["spell-cast-time"] || "",
+      targetNumber: toInt(spell["spell-tn"]) || 0,
+      spellTest: spell["spell-test"] || "",
+    });
+  });
 };
+
+/* Ability-focus repeating sections are named `<ability>-focus`. */
+const FOCUS_SECTIONS: Record<string, string> = {
+  "accuracy-focus": "Accuracy",
+  "communication-focus": "Communication",
+  "constitution-focus": "Constitution",
+  "dexterity-focus": "Dexterity",
+  "fighting-focus": "Fighting",
+  "intelligence-focus": "Intelligence",
+  "perception-focus": "Perception",
+  "strength-focus": "Strength",
+  "willpower-focus": "Willpower",
+};
+
+function applyFocuses(grouped: GroupedRepeating) {
+  Object.entries(FOCUS_SECTIONS).forEach(([section, ability]) => {
+    if (grouped[section]) legacyFocuses(grouped[section], ability);
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Change report                                                              */
+/* -------------------------------------------------------------------------- */
+
+type Change = { path: string; from: any; to: any };
+type ImportReport = { overwritten: Change[]; added: Change[]; cleared: Change[] };
+
+const isEmptyValue = (v: any): boolean =>
+  v === undefined || v === null || v === "";
+
+const fmtValue = (v: any): string => {
+  if (v === undefined) return "(unset)";
+  if (v === "") return '""';
+  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  return s.length > 80 ? `${s.slice(0, 77)}…` : s;
+};
+
+/*
+ * Deep-diffs two dehydrated store snapshots, classifying each changed leaf:
+ *  - overwritten: had a value before, replaced with a different value
+ *  - added:       was empty before, now has a value
+ *  - cleared:     had a value before, now empty
+ */
+function diffStates(
+  before: any,
+  after: any,
+  path = "",
+  report: ImportReport = { overwritten: [], added: [], cleared: [] }
+): ImportReport {
+  const bothObjects =
+    before &&
+    after &&
+    typeof before === "object" &&
+    typeof after === "object";
+  if (bothObjects) {
+    const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+    keys.forEach((key) => {
+      diffStates(
+        before[key],
+        after[key],
+        path ? `${path}.${key}` : key,
+        report
+      );
+    });
+    return report;
+  }
+
+  const beforeEmpty = isEmptyValue(before);
+  const afterEmpty = isEmptyValue(after);
+  if (beforeEmpty && afterEmpty) return report;
+  if (beforeEmpty) {
+    report.added.push({ path, from: before, to: after });
+  } else if (afterEmpty) {
+    report.cleared.push({ path, from: before, to: after });
+  } else if (JSON.stringify(before) !== JSON.stringify(after)) {
+    report.overwritten.push({ path, from: before, to: after });
+  }
+  return report;
+}
+
+function logImportReport(report: ImportReport) {
+  const { overwritten, added, cleared } = report;
+  console.groupCollapsed(
+    `📋 Legacy Import Report — ${overwritten.length} overwritten, ${added.length} added, ${cleared.length} cleared`
+  );
+  if (overwritten.length) {
+    console.warn(
+      `⚠️ Overwritten (${overwritten.length}) — existing values replaced:`
+    );
+    console.table(
+      overwritten.map((c) => ({
+        field: c.path,
+        from: fmtValue(c.from),
+        to: fmtValue(c.to),
+      }))
+    );
+  } else {
+    console.log("✔️ No existing data was overwritten.");
+  }
+  if (added.length) {
+    console.log(`➕ Added (${added.length}) — empty fields filled:`);
+    console.table(added.map((c) => ({ field: c.path, to: fmtValue(c.to) })));
+  }
+  if (cleared.length) {
+    console.log(`➖ Cleared (${cleared.length}) — values removed:`);
+    console.table(
+      cleared.map((c) => ({ field: c.path, from: fmtValue(c.from) }))
+    );
+  }
+  console.groupEnd();
+  return report;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Detection + orchestration                                                  */
+/* -------------------------------------------------------------------------- */
+
+/* True when the blob carries old-format flat data (repeating rows or scalars). */
+export function isLegacyData(attributes: LegacyAttributes): boolean {
+  if (!attributes) return false;
+  if (Object.keys(attributes).some((key) => REPEATING_RE.test(key))) return true;
+  return ["race", "class", "level", "accuracy", "social-class"].some(
+    (key) => !!attributes[key]
+  );
+}
+
+export type ImportMode = "append" | "overwrite";
+
+/* User-selectable sections shown as checkboxes in the Import modal. */
+export const IMPORT_SECTIONS = [
+  { key: "name", label: "Name" },
+  { key: "abilities", label: "Abilities" },
+  { key: "character", label: "Character Stats" },
+  { key: "bio", label: "Biography" },
+  { key: "settings", label: "Game Settings" },
+  { key: "talents", label: "Talents & Powers" },
+  { key: "focuses", label: "Ability Focuses" },
+  { key: "spells", label: "Spells (Arcana)" },
+  { key: "equipment", label: "Equipment & Weapons" },
+  { key: "currency", label: "Currency" },
+] as const;
+
+export type ImportSectionKey = (typeof IMPORT_SECTIONS)[number]["key"];
+
+/* Removes all quality items of the given types (talents, focuses, etc.). */
+function removeQualitiesByType(types: string[]) {
+  const store = useItemStore();
+  store.items
+    .filter((item) => types.includes(item.type))
+    .map((item) => item._id)
+    .forEach((id) => store.removeItem(id));
+}
+
+/* Clears the stores/fields a single section writes to (used by overwrite). */
+function clearSection(key: ImportSectionKey) {
+  switch (key) {
+    case "name":
+      useMetaStore().name = "";
+      break;
+    case "abilities": {
+      const ability = useAbilityScoreStore();
+      Object.values(ABILITY_KEYS).forEach((n) => {
+        (ability as any)[`${n}Base`] = 0;
+      });
+      break;
+    }
+    case "character": {
+      const char = useCharacterStore();
+      char.health = 0;
+      // healthMax / magicMax can't be imported; zero them so the sheet doesn't
+      // keep a stale max from the previous character.
+      char.healthMax = 0;
+      char.magic = 0;
+      char.magicMax = 0;
+      char.armor = 0;
+      char.speed = 0;
+      char.xp = 0;
+      char.weaponGroups = "";
+      break;
+    }
+    case "bio": {
+      const bio = useBioStore();
+      bio.level = 1;
+      bio.ancestry = "";
+      bio.profession = "";
+      bio.background = "";
+      bio.socialClass = "";
+      bio.sex = "";
+      bio.gender = "";
+      bio.height = "";
+      bio.weight = "";
+      bio.eyes = "";
+      bio.skin = "";
+      bio.hair = "";
+      bio.detailsHistory = "";
+      bio.goalsTies = "";
+      bio.relationships = "";
+      bio.age = undefined;
+      removeQualitiesByType(["Ancestry", "Class", "Specialization"]);
+      break;
+    }
+    case "settings":
+      // Re-applying settings is sufficient; nothing to clear.
+      break;
+    case "talents":
+      removeQualitiesByType(["Talent", "Special Feature"]);
+      break;
+    case "focuses":
+      removeQualitiesByType(["Ability Focus"]);
+      break;
+    case "spells":
+      useSpellStore().spells = [];
+      break;
+    case "equipment": {
+      const inv = useInventoryStore();
+      inv.items = inv.items.filter(
+        (i) => i.type !== "item" && i.type !== "weapon"
+      );
+      break;
+    }
+    case "currency":
+      useInventoryStore().cash = { tn: 0, gold: 0, silver: 0, copper: 0 };
+      break;
+  }
+}
+
+/* Imports a single section's data from the legacy blob. */
+function applySection(
+  key: ImportSectionKey,
+  attributes: LegacyAttributes,
+  grouped: GroupedRepeating,
+  name?: string
+) {
+  switch (key) {
+    case "name":
+      if (name) useMetaStore().name = name;
+      break;
+    case "abilities":
+      importLegacyAbilityScores(attributes);
+      break;
+    case "character":
+      importLegacyCharacterFlat(attributes);
+      break;
+    case "bio":
+      importLegacyBioFlat(attributes);
+      importLegacyAncestryClass(attributes);
+      importLegacySpecialization(attributes);
+      break;
+    case "settings":
+      importLegacySettingsFlat(attributes);
+      break;
+    case "talents":
+      legacyTalents(grouped.talent);
+      legacyPowers(grouped.power);
+      break;
+    case "focuses":
+      applyFocuses(grouped);
+      break;
+    case "spells":
+      legacyArcana(grouped.spell);
+      break;
+    case "equipment":
+      legacyInventory(grouped.equipment);
+      legacyAttackWeapons(grouped["attack-list"]);
+      break;
+    case "currency":
+      legacyCurrency(grouped.money);
+      break;
+  }
+}
+
+/*
+ * Full import — the action behind the Import modal. `sections` selects which
+ * parts to import (defaults to all). In overwrite mode each selected section's
+ * targets are cleared before importing.
+ */
+export function importLegacyCharacter(
+  attributes: LegacyAttributes,
+  mode: ImportMode = "append",
+  sections?: string[],
+  name?: string
+) {
+  // Guard: never clear/overwrite the sheet when there's no legacy data to
+  // import (e.g. the character blob hasn't loaded yet).
+  if (!attributes || !isLegacyData(attributes)) {
+    console.warn(
+      "⚠️ Legacy import skipped: no legacy character data found in the blob."
+    );
+    return;
+  }
+  const selected = (
+    sections && sections.length ? sections : IMPORT_SECTIONS.map((s) => s.key)
+  ) as ImportSectionKey[];
+
+  const sheet = useAgeSheetStore();
+  const before = sheet.dehydrateStore();
+  const grouped = groupRepeating(attributes);
+
+  if (mode === "overwrite") selected.forEach((key) => clearSection(key));
+  selected.forEach((key) => applySection(key, attributes, grouped, name));
+
+  const after = sheet.dehydrateStore();
+  logImportReport(diffStates(before, after));
+  console.info("✅ Legacy import complete");
+}

--- a/ageofficial/src/views/SettingsView.vue
+++ b/ageofficial/src/views/SettingsView.vue
@@ -87,10 +87,16 @@
             </div>
             <div class="mb-3 col age-import-toggle-cell">
               <label class="age-checkbox-toggle age-checkbox-label">
-                <input type="checkbox" v-model="settings.allowImport" />
+                <input
+                  id="settings-allow-import"
+                  type="checkbox"
+                  v-model="settings.allowImport"
+                />
                 <span class="slider round"></span>
               </label>
-              <span class="age-toggle-label">Allow Import</span>
+              <label class="age-toggle-label" for="settings-allow-import"
+                >Allow Import</label
+              >
             </div>
           </div>
           <!-- // TODO Items unique to genre slices. Technofantasy, Cthulhu Awakens, Cyberpunk, etc. -->

--- a/ageofficial/src/views/SettingsView.vue
+++ b/ageofficial/src/views/SettingsView.vue
@@ -85,6 +85,13 @@
                 <option value="gritty">Gritty</option>
               </select>
             </div>
+            <div class="mb-3 col age-import-toggle-cell">
+              <label class="age-checkbox-toggle age-checkbox-label">
+                <input type="checkbox" v-model="settings.allowImport" />
+                <span class="slider round"></span>
+              </label>
+              <span class="age-toggle-label">Allow Import</span>
+            </div>
           </div>
           <!-- // TODO Items unique to genre slices. Technofantasy, Cthulhu Awakens, Cyberpunk, etc. -->
           <div
@@ -494,6 +501,14 @@ const updateExpanseFaction = () => {
 
 <style lang="scss" scoped>
 @use "../common/scss/vars.scss";
+/* Toggle sits in the Game System row; align it to the row floor (level with the
+   bottom of the select boxes), toggle first then black label. */
+.age-import-toggle-cell {
+  display: flex;
+  align-items: center;
+  align-self: flex-end;
+  gap: 8px;
+}
 .myButton {
   background-color: #595959;
   border-radius: 6px;

--- a/ageofficial/vitest.config.ts
+++ b/ageofficial/vitest.config.ts
@@ -5,9 +5,14 @@ import svgLoader from "vite-svg-loader";
 
 export default defineConfig({
   plugins: [vue(), svgLoader()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url))
+    }
+  },
   test: {
     environment: "jsdom",
-    exclude: [...configDefaults.exclude, "e2e/*"],
+    exclude: [...configDefaults.exclude, "e2e/*", "**/.worktrees/**"],
     root: fileURLToPath(new URL("./", import.meta.url))
   }
 });


### PR DESCRIPTION
## Submission Checklist
- [x] The Pull Request title contains the **short name** of the sheet being submitted.
- [x] The Pull Request title states the **type of change** being submitted (New/Update/Bugfix/etc.).
- [x] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [x] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [x] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description (optional)

# Add legacy Roll20 character import to the AGE sheet

## Summary

Adds a **legacy character importer** to the AGE (Adventure Game Engine) sheet.
It reads the flat Roll20 attribute blob from an old-format character
(`repeating_*` rows + top-level scalars) and maps it into the Beacon SDK
Pinia stores, so players can migrate existing characters onto the new sheet.

Implemented in `src/utility/legacyAdapter.ts`, driven by a new Import modal in
`App.vue`, and gated behind a new **Allow Import** setting.

## What it does

**Import UI**
- A slide-out **Import** tab pinned to the right edge of the sheet. It tucks
  mostly off-screen and slides out on hover/keyboard-focus so it doesn't
  interfere with play. The icon is a CSS mask/background image that themes per
  game system (Fantasy AGE / Blue Rose vs. Modern AGE / Expanse), with a
  screen-reader-only label and an "Import" tooltip.
- Gated behind a new **Allow Import** toggle in Sheet Settings (Game System
  row), **default off** — opt-in per character.
- Clicking Import opens a modal that pulls from the live character and offers
  **per-section checkboxes**: Name, Abilities, Character Stats, Biography,
  Game Settings, Talents & Powers, Ability Focuses, Spells (Arcana),
  Equipment & Weapons, Currency.
- Two apply modes: **Append** (add on top of existing data) and **Overwrite**
  (clear the selected sections first, then import). Overwrite only clears the
  sections the user checked.

**Mapping** (`legacyAdapter.ts`)
- Ability scores, character stats (health/magic, armor, base-speed, weapon
  groups, xp, level), biography (ancestry, class, background, physical,
  history, goals), and game settings (game system, caster → show Arcana).
- Talents & powers, ability focuses (per-ability repeating sections),
  specializations, and ancestry/class → quality items.
- Spells/arcana → the magic store; equipment and attacks → inventory items
  (a legacy attack implies possession of the weapon, so it becomes an
  inventory weapon).
- Robust parsing for real-world messiness: inconsistent money formats
  (`"18g"`, `"GP"+"6"`, reversed `"10"+"G"`), split/ranged attack ranges
  (`"4 / 6"`, `"16 yards"`), and hyphenated repeating-section names.

**Safety**
- A guard skips the import (with a console warning) when the blob has no legacy
  data, so an empty/not-yet-loaded character can never blank the sheet.
- Persistence flows through the normal relay dehydrate/update cycle; the
  existing `updateId` check prevents the re-hydrate loop from clobbering an
  import.

## Other changes

- **`AbilitiesView.vue`**: the ability display was built from a one-time
  snapshot `ref` (only refreshed when the abilities modal closed), so external
  store changes never showed. Changed to a `computed` — a latent reactivity
  bug that the importer surfaced.
- **`vitest.config.ts`**: added the `@` alias (needed to unit-test modules that
  use it) and excluded nested `.worktrees` so the unit suite runs cleanly.
- **`settingsStore.ts`**: new persisted `allowImport` flag (default `false`).

## Testing

- `src/utility/legacyAdapter.spec.ts` — 8 tests covering the flat import
  (warrior + mage sample characters), section selection, overwrite clearing,
  messy money/range parsing, and the empty-blob guard. All pass.
- `npm run type-check` is clean for the changed files.

## Known limitations / follow-ups

- **Fantasy AGE validated.** Field mappings are verified against Fantasy AGE
  characters. Modern AGE / Expanse / Blue Rose legacy field names are untested
  and may import partially.
- **healthMax / magicMax** aren't imported (missing from the Roll20 export);
  the player enters the real max after import.
- **No dedup** of quality items — messy legacy data (e.g., duplicated talent
  rows) imports verbatim.
- Imported weapons don't map an ability for attack rolls (default Strength);
  `languages`, appearance, and computed aggregates (armor penalty/shield bonus)
  are dropped.
- Pre-existing `settingsStore.test.ts` asserts an outdated `dehydrate()` shape
  and remains red (unrelated to this feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added legacy character import with selectable sections and append or overwrite options.
  * Added an “Allow Import” setting to control access to character imports.
  * Added support for importing abilities, details, inventory, weapons, spells, currency, and other character data.
* **Bug Fixes**
  * Ability scores now update automatically when changes are made elsewhere in the app.
* **Tests**
  * Added comprehensive coverage for legacy imports, selective updates, parsing, and invalid data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->